### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/.changeset/stupid-seals-jump.md
+++ b/.changeset/stupid-seals-jump.md
@@ -1,0 +1,6 @@
+---
+'@mheob/eslint-config': major
+'@mheob/prettier-config': major
+---
+
+Initial configuration

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "@changesets/cli": "^2.24.0",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
-    "@mheob/eslint-config": "workspace:*",
-    "@mheob/prettier-config": "workspace:*",
+    "@mheob/eslint-config": "workspace:0.0.0",
+    "@mheob/prettier-config": "workspace:0.0.0",
     "eslint": "^8.20.0",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "simple-git-hooks": "^2.8.0",
     "turbo": "^1.3.4"
   },
-  "packageManager": "pnpm@7.5.2",
+  "packageManager": "pnpm@7.6.0",
   "engines": {
     "node": ">=16.0.0",
     "npm": ">=8.0.0"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -25,7 +25,7 @@
     "lint": "TIMING=1 eslint src/**/*.ts* --fix"
   },
   "dependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^3.2.0"
+    "@trivago/prettier-plugin-sort-imports": "^3.3.0"
   },
   "devDependencies": {
     "@mheob/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ importers:
       '@changesets/cli': ^2.24.0
       '@commitlint/cli': ^17.0.3
       '@commitlint/config-conventional': ^17.0.3
-      '@mheob/eslint-config': workspace:*
-      '@mheob/prettier-config': workspace:*
+      '@mheob/eslint-config': workspace:0.0.0
+      '@mheob/prettier-config': workspace:0.0.0
       eslint: ^8.20.0
       lint-staged: ^13.0.3
       prettier: ^2.7.1
@@ -54,7 +54,7 @@ importers:
   packages/prettier-config:
     specifiers:
       '@mheob/eslint-config': workspace:*
-      '@trivago/prettier-plugin-sort-imports': ^3.2.0
+      '@trivago/prettier-plugin-sort-imports': ^3.3.0
       eslint: ^8.20.0
       prettier: ^2.7.1
     dependencies:
@@ -94,14 +94,14 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.17.7
+      '@babel/generator': 7.18.9
       '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.17.8
       '@babel/helper-module-transforms': 7.18.9
       '@babel/helpers': 7.18.9
-      '@babel/parser': 7.17.8
+      '@babel/parser': 7.18.9
       '@babel/template': 7.18.6
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/traverse': 7.18.9
+      '@babel/types': 7.18.9
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -115,7 +115,7 @@ packages:
     resolution: {integrity: sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.9
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
@@ -232,7 +232,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.9
     dev: false
 
   /@babel/parser/7.18.9:
@@ -271,13 +271,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.17.7
+      '@babel/generator': 7.18.9
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.18.9
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.17.8
-      '@babel/types': 7.17.0
+      '@babel/parser': 7.18.9
+      '@babel/types': 7.18.9
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -583,10 +583,10 @@ packages:
       '@commitlint/execute-rule': 17.0.0
       '@commitlint/resolve-extends': 17.0.3
       '@commitlint/types': 17.0.0
-      '@types/node': 12.20.55
+      '@types/node': 18.0.6
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_rf36vhyq5bw7w55ijgrvnfasgy
+      cosmiconfig-typescript-loader: 2.0.2_tdn3ypgnfy6bmey2q4hu5jonwi
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.7.4
@@ -841,6 +841,10 @@ packages:
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    dev: true
+
+  /@types/node/18.0.6:
+    resolution: {integrity: sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -1377,16 +1381,16 @@ packages:
     requiresBuild: true
     dev: false
 
-  /cosmiconfig-typescript-loader/2.0.2_rf36vhyq5bw7w55ijgrvnfasgy:
+  /cosmiconfig-typescript-loader/2.0.2_tdn3ypgnfy6bmey2q4hu5jonwi:
     resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@types/node': '*'
       typescript: '>=3'
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 18.0.6
       cosmiconfig: 7.0.1
-      ts-node: 10.9.1_rf36vhyq5bw7w55ijgrvnfasgy
+      ts-node: 10.9.1_tdn3ypgnfy6bmey2q4hu5jonwi
       typescript: 4.7.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -3644,7 +3648,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-node/10.9.1_rf36vhyq5bw7w55ijgrvnfasgy:
+  /ts-node/10.9.1_tdn3ypgnfy6bmey2q4hu5jonwi:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -3663,7 +3667,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 12.20.55
+      '@types/node': 18.0.6
       acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
Bump the following dependencies:

- `pnpm` to `7.6.0`
- `@trivago/prettier-plugin-sort-imports` to `3.3.0`