### PR TITLE
ci(release): use correct commit message

### DIFF
--- a/.changeset/blue-ears-marry.md
+++ b/.changeset/blue-ears-marry.md
@@ -1,6 +1,0 @@
----
-'@mheob/eslint-config': major
-'@mheob/prettier-config': major
----
-
-Initial configuration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,6 @@
 name: Release
 
-on:
-  push:
-    paths:
-      - ".changeset/**"
-      - "packages/**"
-
-    branches:
-      - main
+on: workflow_dispatch
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -37,7 +30,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          commit: "chore(release): bump version and deploy packages"
+          title: "chore(release): bump version and deploy packages"
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `changeset` workflow has tried to use a commit message that does not match the `commitlint` rules.
We now specify our message.

Furthermore, the release workflow is now only triggered manually.