### PR TITLE
ci(git): remove wrong `commit-msg` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged",
-    "commit-msg": "pnpm exec commitlint --edit ${1}",
-    "pre-push": "./tools/bin/check_lock_files"
+    "commit-msg": "pnpm exec commitlint --edit ${1}"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
The `pre-push` hook `./tools/bin/check_lock_files` was added accidentally. It will be removed now.