### PR TITLE
feat(prettier): add more rules

### DIFF
--- a/.changeset/light-hotels-stare.md
+++ b/.changeset/light-hotels-stare.md
@@ -1,0 +1,5 @@
+---
+"@mheob/prettier-config": minor
+---
+
+Add some more rules like using tabs and some more.

--- a/packages/prettier-config/index.cjs
+++ b/packages/prettier-config/index.cjs
@@ -3,6 +3,8 @@ const sortImports = require('@trivago/prettier-plugin-sort-imports');
 /** @type {import('prettier').Config} */
 module.exports = {
   plugins: [sortImports],
+  arrowParens: 'always',
+  endOfLine: 'lf',
   printWidth: 100,
   proseWrap: 'always',
   importOrder: ['^node:', '<THIRD_PARTY_MODULES>', '^[./]'],
@@ -10,6 +12,10 @@ module.exports = {
   importOrderSortSpecifiers: true,
   singleQuote: true,
   semi: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+  useTabs: false,
+
   overrides: [
     {
       files: '*.{yaml,yml}',


### PR DESCRIPTION
Add prettier rules to specify the rule set a bitt more.

The new added rules are:

```jsonc
{
  // …
  "arrowParens": "always",
  "endOfLine": "lf",
  // …
  "tabWidth": 2,
  "trailingComma": "all",
  "useTabs": false,
  // …
}
```