### PR TITLE
chore: improve kodiak automerge

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -4,6 +4,7 @@ version = 1
 require_automerge_label = false
 method = "squash"
 delete_branch_on_merge = true
+optimistic_updates = false
 
 [merge.message]
 title = "pull_request_title"


### PR DESCRIPTION
It slows down the execution of Kodiak a bit to make sure that all status checks have been performed.