### PR TITLE
Improve prettier

### DIFF
--- a/.changeset/curly-icons-serve.md
+++ b/.changeset/curly-icons-serve.md
@@ -1,0 +1,5 @@
+---
+"@mheob/prettier-config": minor
+---
+
+Set markdown `printWidth` to `130`.

--- a/.changeset/wet-lobsters-flow.md
+++ b/.changeset/wet-lobsters-flow.md
@@ -1,0 +1,5 @@
+---
+"@mheob/prettier-config": patch
+---
+
+Improve README to get a better copy/paste experience.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -2,33 +2,27 @@
 
 To make my configurations a bit easier I share my [Prettier](https://prettier.io) config.
 
-## Usage
+## Install
 
-### Install
+### With NPM
 
 ```sh
-# with npm
 npm install -D @mheob/prettier-config
+```
 
-# with yarn
+### With YARN
+
+```sh
 yarn add -D @mheob/prettier-config
+```
 
-# with pnpm
+### With PNPM
+
+```sh
 pnpm add -D @mheob/prettier-config
 ```
 
-### Include in your project
-
-#### Simple: Edit `package.json`
-
-```jsonc
-{
-  // ...
-  "prettier": "@mheob/prettier-config"
-}
-```
-
-#### Or with override settings
+## Usage
 
 If you need to override some settings you can do it this way:
 
@@ -43,8 +37,7 @@ module.exports = {
 
 ## Ruleset
 
-This configuration uses the
-[`@trivago/prettier-plugin-sort-imports`](https://github.com/trivago/prettier-plugin-sort-imports)
+This configuration uses the [`@trivago/prettier-plugin-sort-imports`](https://github.com/trivago/prettier-plugin-sort-imports)
 plugin and set these styles:
 
 ```js

--- a/packages/prettier-config/index.cjs
+++ b/packages/prettier-config/index.cjs
@@ -25,5 +25,11 @@ module.exports = {
         singleQuote: false,
       },
     },
+    {
+      files: '*.md',
+      options: {
+        printWidth: 130,
+      },
+    },
   ],
 };

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-    "lint": "TIMING=1 eslint src/**/*.ts* --fix"
+    "lint": "TIMING=1 eslint **/*.cjs --fix"
   },
   "dependencies": {
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",


### PR DESCRIPTION
## 📑 Description

- Set markdown `printWidth` to `130`
- Improve documentation by splitting installation script snippets