### PR TITLE
fix(eslint): use correct `index.js`

### DIFF
--- a/.changeset/funny-donkeys-watch.md
+++ b/.changeset/funny-donkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"@mheob/eslint-config": patch
+---
+
+Change old and wrong `main` file name in `package.json` from `index.cjs` to `index.js`.

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "author": "Alexander Böhm <tools@boehm.work>",
-  "main": "index.cjs",
+  "main": "index.js",
   "files": [
     "index.js",
     "base.js",


### PR DESCRIPTION
Resolves #22

## 📑 Description

Change old and wrong `main` file name in `package.json` from `index.cjs` to `index.js`.