### PR TITLE
feat(eslint): add more typescript specific rules

### DIFF
--- a/.changeset/spotty-coats-carry.md
+++ b/.changeset/spotty-coats-carry.md
@@ -1,0 +1,5 @@
+---
+"@mheob/eslint-config": patch
+---
+
+Add more typescript specific rules.

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -33,13 +33,19 @@ module.exports = {
       rules: { 'unicorn/filename-case': ['error', { case: 'camelCase' }] },
     },
     {
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx'],
       extends: ['plugin:@typescript-eslint/recommended'],
       rules: {
+        '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/explicit-function-return-type': [
           'warn',
           { allowExpressions: true, allowTypedFunctionExpressions: true },
         ],
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+        ],
+        '@typescript-eslint/quotes': ['warn', 'single', { avoidEscape: true }],
       },
     },
   ],


### PR DESCRIPTION
Add more typescript specific rules:

```js
rules: {
  '@typescript-eslint/consistent-type-imports': 'error',
  '@typescript-eslint/explicit-function-return-type': [
    'warn',
    { allowExpressions: true, allowTypedFunctionExpressions: true },
  ],
  '@typescript-eslint/no-unused-vars': [
    'warn',
    { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
  ],
  '@typescript-eslint/quotes': ['warn', 'single', { avoidEscape: true }],
},
```