### PR TITLE
feat(eslint): deactivate `.../explicit-function-return-type` eslint rule

### DIFF
--- a/.changeset/healthy-donuts-live.md
+++ b/.changeset/healthy-donuts-live.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+Deactivate `@typescript-eslint/explicit-function-return-type` rule for jsx files.

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -14,6 +14,7 @@ module.exports = {
       files: ['*.jsx', '*.tsx'],
       settings: { react: { version: 'detect' } },
       rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
         'react/jsx-curly-brace-presence': ['warn', { props: 'never', children: 'never' }],
         'react/jsx-no-useless-fragment': 'warn',
         'react/react-in-jsx-scope': 'off',


### PR DESCRIPTION
Deactivate the `@typescript-eslint/explicit-function-return-type` rule for JSX files.
