### PR TITLE
chore(ci): fix "Author identity unknown" error

### DIFF
--- a/.changeset/friendly-ads-travel.md
+++ b/.changeset/friendly-ads-travel.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+chore(ci): fix "Author identity unknown" error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
           commit: "chore(release): bump version and deploy packages"
           title: "chore(release): bump version and deploy packages"
           publish: pnpm run release
-          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes the "Author identity unknown" error by removing `setupGitUser` config again.