### PR TITLE
feat(eslint): disable `no-array-for-each` rule

### DIFF
--- a/.changeset/clean-singers-press.md
+++ b/.changeset/clean-singers-press.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+Disable `unicorn/no-array-for-each` rule as default

--- a/packages/eslint-config/src/base.ts
+++ b/packages/eslint-config/src/base.ts
@@ -9,6 +9,7 @@ const config: Linter.Config = {
 		'no-implicit-coercion': ['error', { allow: ['!!', '+', '~'] }],
 		'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
 		'unicorn/import-index': 'error',
+		'unicorn/no-array-for-each': 'off',
 		'unicorn/prevent-abbreviations': [
 			'error',
 			{


### PR DESCRIPTION
Disable `unicorn/no-array-for-each` rule by default can help writing cleaner code.