### PR TITLE
fix(eslint, prettier): describe auto fix of import sorts in READMEs

### DIFF
--- a/.changeset/pretty-pets-develop.md
+++ b/.changeset/pretty-pets-develop.md
@@ -1,0 +1,6 @@
+---
+'@mheob/prettier-config': patch
+'@mheob/eslint-config': patch
+---
+
+Fix the README files after the change of using ESLint to fix the imports.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -54,6 +54,8 @@ module.exports = {
 };
 ```
 
+## Overwrite Rules
+
 If you need to override some rules you can do it this way:
 
 ```js
@@ -62,8 +64,29 @@ module.exports = {
 	root: true, // optional
 	extends: ['@mheob/eslint-config'],
 	rules: {
-		'prettier/prettier': 'off',
 		'no-console': 'warn',
+		'prettier/prettier': 'off',
+		'simple-import-sort/imports': [
+			'error',
+			{
+				groups: [
+					// Side effect imports
+					['^\\u0000'],
+					// Node.js builtins
+					['^node:'],
+					// Packages
+					['^@?\\w'],
+					// Internal packages
+					['^~/?\\w'],
+					// Absolute imports
+					['^'],
+					// Relative imports
+					['^\\.'],
+					// Style imports
+					['^.+\\.s?css$'],
+				],
+			},
+		],
 	},
 };
 ```
@@ -80,8 +103,8 @@ module.exports = {
 			files: ['*.jsx', '*.tsx'],
 			settings: { react: { version: 'detect' } },
 			rules: {
-				'react/jsx-no-useless-fragment': 'warn',
-				'react/react-in-jsx-scope': 'off',
+				'react/jsx-no-useless-fragment': 'error',
+				'unicorn/filename-case': ['error', { case: 'kebabCase' }],
 			},
 		},
 	],

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -31,27 +31,21 @@ If you need to override some settings you can do it this way:
 module.exports = {
 	...require('@mheob/prettier-config'),
 	semi: false,
-	importOrder: ['^@company/(.*)$', '^[./]'],
+	useTabs: false,
 };
 ```
 
 ## Ruleset
 
-This configuration uses the [`@trivago/prettier-plugin-sort-imports`](https://github.com/trivago/prettier-plugin-sort-imports) plugin and set these styles:
+This configuration uses these styles:
 
 ```js
-const sortImports = require('@trivago/prettier-plugin-sort-imports');
-
 /** @type {import('prettier').Config} */
 module.exports = {
-	plugins: [sortImports],
 	arrowParens: 'always',
 	endOfLine: 'lf',
 	printWidth: 100,
 	proseWrap: 'always',
-	importOrder: ['^node:', '<THIRD_PARTY_MODULES>', '^[./]'],
-	importOrderSeparation: true,
-	importOrderSortSpecifiers: true,
 	singleQuote: true,
 	semi: true,
 	trailingComma: 'all',


### PR DESCRIPTION
Resolves #105

## 📑 Description

Fix the README files after the change of using ESLint to fix the imports.
