### PR TITLE
feat(eslint): move `explicit-function-return-type` rule to base config

### DIFF
--- a/.changeset/pretty-taxis-provide.md
+++ b/.changeset/pretty-taxis-provide.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+move `explicit-function-return-type` rule to base config

--- a/packages/eslint-config/src/base.ts
+++ b/packages/eslint-config/src/base.ts
@@ -75,6 +75,7 @@ const config: Linter.Config = {
 			extends: ['plugin:@typescript-eslint/recommended'],
 			rules: {
 				'@typescript-eslint/consistent-type-imports': 'error',
+				'@typescript-eslint/explicit-function-return-type': 'off',
 				// Disable the default rule so that `unused-imports` can auto-fix
 				'@typescript-eslint/no-unused-vars': 'off',
 				'@typescript-eslint/quotes': ['warn', 'single', { avoidEscape: true }],

--- a/packages/eslint-config/src/react.ts
+++ b/packages/eslint-config/src/react.ts
@@ -12,7 +12,6 @@ const config: Linter.Config = {
 			files: ['*.jsx', '*.tsx'],
 			settings: { react: { version: 'detect' } },
 			rules: {
-				'@typescript-eslint/explicit-function-return-type': 'off',
 				'react/jsx-curly-brace-presence': ['warn', { props: 'never', children: 'never' }],
 				'react/jsx-no-useless-fragment': 'warn',
 				'react/react-in-jsx-scope': 'off',


### PR DESCRIPTION
Move the deactivation of the `@typescript-eslint/explicit-function-return-type` rule to the base config.