### PR TITLE
feat(eslint)!: drop CJS build

### DIFF
--- a/.changeset/light-colts-complain.md
+++ b/.changeset/light-colts-complain.md
@@ -1,0 +1,7 @@
+---
+'@mheob/eslint-config': major
+---
+
+drop CJS build
+
+BREAKING CHANGE: use `eslint.config.mjs` instead of `eslint.config.cjs`

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,10 +16,7 @@
 	"author": "Alexander Böhm <tools@boehm.work>",
 	"type": "module",
 	"exports": {
-		".": {
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
-		}
+		".": "./dist/index.js"
 	},
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/packages/eslint-config/tsup.config.ts
+++ b/packages/eslint-config/tsup.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'tsup';
 export default defineConfig(options => ({
 	dts: true,
 	entry: ['src/index.ts'],
-	format: ['cjs', 'esm'],
+	format: ['esm'],
 	minify: !options.watch,
 }));


### PR DESCRIPTION
BREAKING CHANGE: use `eslint.config.mjs` instead of `eslint.config.cjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Dropped CommonJS (CJS) build for `@mheob/eslint-config`
	- Requires migration to `eslint.config.mjs` configuration file
	- Updated package to use only ESM module format

- **Migration Notes**
	- Users must update their ESLint configuration to use the new module format
	- Remove any CommonJS-specific import/require statements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->