### PR TITLE
feat(eslint): add cli for initial configuration

### DIFF
--- a/.changeset/chilly-rivers-own.md
+++ b/.changeset/chilly-rivers-own.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+add cli for initial configuration

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,20 @@
 		"source.organizeImports": "never"
 	},
 
+	// Silent the stylistic rules in you IDE, but still auto fix them
+	"eslint.rules.customizations": [
+		{ "rule": "style/*", "severity": "off", "fixable": true },
+		{ "rule": "format/*", "severity": "off", "fixable": true },
+		{ "rule": "*-indent", "severity": "off", "fixable": true },
+		{ "rule": "*-spacing", "severity": "off", "fixable": true },
+		{ "rule": "*-spaces", "severity": "off", "fixable": true },
+		{ "rule": "*-order", "severity": "off", "fixable": true },
+		{ "rule": "*-dangle", "severity": "off", "fixable": true },
+		{ "rule": "*-newline", "severity": "off", "fixable": true },
+		{ "rule": "*quotes", "severity": "off", "fixable": true },
+		{ "rule": "*semi", "severity": "off", "fixable": true }
+	],
+
 	// Enable eslint for all supported languages
 	"eslint.validate": [
 		"javascript",
@@ -27,6 +41,7 @@
 		"html",
 		"markdown",
 		"json",
+		"json5",
 		"jsonc",
 		"yaml",
 		"toml",
@@ -34,6 +49,7 @@
 		"gql",
 		"graphql",
 		"astro",
+		"svelte",
 		"css",
 		"less",
 		"scss",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
 		"clean:root": "rm -rf .turbo && rm -rf node_modules",
 		"cspell": "cspell .",
 		"format": "prettier --write \"**/*.{cjs,js,mjs,ts,json,md,mdx,yaml,yml}\"",
+		"gen": "turbo run gen",
 		"lint": "turbo run lint",
 		"prepare": "husky",
 		"release": "changeset publish",
 		"typegen": "turbo run typegen",
-		"version-packages": "changeset version && pnpm lint"
+		"version-packages": "changeset version && pnpm lint",
+		"versiongen": "turbo run versiongen"
 	},
 	"lint-staged": {
 		"*": "eslint --fix"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -7,31 +7,35 @@ To make my configurations a bit easier I share my [ESLint](https://eslint.org/) 
 
 You can find all used rules in my deployed [ESLint Config Inspector](https://eslint-config.mheob.dev/configs).
 
-## Install
+## Starter Wizard
 
-### With NPM
-
-```sh
-npm install -D @mheob/eslint-config
-```
-
-### With YARN
+I provide a CLI tool to help you set up your project, or migrate from the legacy config to the new flat config with one command.
 
 ```sh
-yarn add -D @mheob/eslint-config
+pnpm dlx @mheob/eslint-config@latest
 ```
 
-### With PNPM
+or
+
+```sh
+bunx @mheob/eslint-config@latest
+```
+
+or use your package manager of choice.
+
+## Manual Install
 
 ```sh
 pnpm add -D @mheob/eslint-config
 ```
 
-### With BUN
+or
 
 ```sh
 bun add -d @mheob/eslint-config
 ```
+
+or use your package manager of choice.
 
 ## Usage
 

--- a/packages/eslint-config/bin/index.js
+++ b/packages/eslint-config/bin/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/cli.js';

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,6 +4,7 @@
 	"description": "My personal configuration for eslint.",
 	"keywords": [
 		"eslint",
+		"eslint-config",
 		"config"
 	],
 	"homepage": "https://github.com/mheob/config/tree/main/packages/eslint-config",
@@ -18,9 +19,11 @@
 	"exports": {
 		".": "./dist/index.js"
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": "./bin/index.js",
 	"files": [
+		"bin",
 		"dist"
 	],
 	"scripts": {
@@ -30,6 +33,7 @@
 		"dev": "pnpm exec config-inspector --config ../../eslint.config.js",
 		"lint": "eslint src/**/* --fix",
 		"typegen": "node --import tsx/esm scripts/typegen.ts",
+		"versiongen": "node --import tsx/esm scripts/versiongen.ts",
 		"watch": "tsup --watch"
 	},
 	"dependencies": {
@@ -39,6 +43,8 @@
 		"@typescript-eslint/eslint-plugin": "^8.29.1",
 		"@typescript-eslint/parser": "^8.29.1",
 		"@vitest/eslint-plugin": "^1.1.42",
+		"ansis": "^3.17.0",
+		"cac": "^6.7.14",
 		"eslint-config-flat-gitignore": "^2.1.0",
 		"eslint-config-next": "^15.3.0",
 		"eslint-config-prettier": "^10.1.2",

--- a/packages/eslint-config/scripts/versiongen.ts
+++ b/packages/eslint-config/scripts/versiongen.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs/promises';
+
+import { dependencies, devDependencies } from '../package.json';
+import { dependenciesMap } from '../src/cli/constants';
+
+const names = [...new Set(['eslint', ...Object.values(dependenciesMap).flat()])];
+const allDependencies = { ...dependencies, ...devDependencies };
+
+const versions = Object.fromEntries(
+	names
+		.map(name => {
+			const version = allDependencies[name];
+			if (!version) {
+				throw new Error(`Dependency "${name}" not found in package.json dependencies`);
+			}
+			return [name, version];
+		})
+		.sort((a, b) => a[0].localeCompare(b[0])),
+);
+
+const targetFile = '../src/cli/versions-map.generated.ts';
+
+await fs.writeFile(
+	new URL(targetFile, import.meta.url),
+	`export const versionsMap = ${JSON.stringify(versions, null, '\t')}`,
+);

--- a/packages/eslint-config/src/cli.ts
+++ b/packages/eslint-config/src/cli.ts
@@ -1,0 +1,1 @@
+export * from './cli/index';

--- a/packages/eslint-config/src/cli/constants.ts
+++ b/packages/eslint-config/src/cli/constants.ts
@@ -1,0 +1,88 @@
+import c from 'ansis';
+
+import type { FrameworkOption, PromptItem } from './types';
+
+export const vscodeSettingsString = `
+  // Disable the default formatter, use eslint instead
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+
+  // Auto fix
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
+  },
+
+  // Silent the stylistic rules in you IDE, but still auto fix them
+  "eslint.rules.customizations": [
+    { "rule": "style/*", "severity": "off", "fixable": true },
+    { "rule": "format/*", "severity": "off", "fixable": true },
+    { "rule": "*-indent", "severity": "off", "fixable": true },
+    { "rule": "*-spacing", "severity": "off", "fixable": true },
+    { "rule": "*-spaces", "severity": "off", "fixable": true },
+    { "rule": "*-order", "severity": "off", "fixable": true },
+    { "rule": "*-dangle", "severity": "off", "fixable": true },
+    { "rule": "*-newline", "severity": "off", "fixable": true },
+    { "rule": "*quotes", "severity": "off", "fixable": true },
+    { "rule": "*semi", "severity": "off", "fixable": true }
+  ],
+
+  // Enable eslint for all supported languages
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue",
+    "html",
+    "markdown",
+    "json",
+    "json5",
+    "jsonc",
+    "yaml",
+    "toml",
+    "xml",
+    "gql",
+    "graphql",
+    "astro",
+    "svelte",
+    "css",
+    "less",
+    "scss",
+    "pcss",
+    "postcss"
+  ]
+`;
+
+export const frameworkOptions: PromptItem<FrameworkOption>[] = [
+	{
+		label: c.green('Vue'),
+		value: 'vue',
+	},
+	{
+		label: c.cyan('React'),
+		value: 'react',
+	},
+	{
+		label: c.red('Svelte'),
+		value: 'svelte',
+	},
+	{
+		label: c.magenta('Astro'),
+		value: 'astro',
+	},
+];
+
+export const frameworks: FrameworkOption[] = frameworkOptions.map(({ value }) => value);
+
+export const dependenciesMap = {
+	astro: ['eslint-plugin-astro', 'astro-eslint-parser'],
+	formatterAstro: ['prettier-plugin-astro'],
+	react: [
+		'@eslint-react/eslint-plugin',
+		'eslint-plugin-react-hooks',
+		'eslint-plugin-react-refresh',
+	],
+	svelte: ['eslint-plugin-svelte', 'svelte-eslint-parser'],
+	vue: [],
+} as const;

--- a/packages/eslint-config/src/cli/index.ts
+++ b/packages/eslint-config/src/cli/index.ts
@@ -1,0 +1,38 @@
+import process from 'node:process';
+
+import * as p from '@clack/prompts';
+import c from 'ansis';
+import { cac } from 'cac';
+
+import { version } from '../../package.json';
+import { run } from './run';
+
+function header(): void {
+	console.log('\n');
+	p.intro(`${c.green`@mheob/eslint-config `}${c.dim`v${version}`}`);
+}
+
+const cli = cac('@mheob/eslint-config');
+
+cli
+	.command('', 'Run the initialization or migration')
+	.option('--yes, -y', 'Skip prompts and use default values', { default: false })
+	.option(
+		'--template, -t <template>',
+		'Use the framework template for optimal customization: vue / react / svelte / astro',
+		{ type: [] },
+	)
+	.action(async args => {
+		header();
+		try {
+			await run(args);
+		} catch (error) {
+			p.log.error(c.inverse.red(' Failed to migrate '));
+			p.log.error(c.red`✘ ${String(error)}`);
+			process.exit(1);
+		}
+	});
+
+cli.help();
+cli.version(version);
+cli.parse();

--- a/packages/eslint-config/src/cli/index.ts
+++ b/packages/eslint-config/src/cli/index.ts
@@ -7,12 +7,14 @@ import { cac } from 'cac';
 import { version } from '../../package.json';
 import { run } from './run';
 
+const PACKAGE_NAME = '@mheob/eslint-config';
+
 function header(): void {
 	console.log('\n');
-	p.intro(`${c.green`@mheob/eslint-config `}${c.dim`v${version}`}`);
+	p.intro(c.green`${PACKAGE_NAME} ` + c.dim`v${version}`);
 }
 
-const cli = cac('@mheob/eslint-config');
+const cli = cac(PACKAGE_NAME);
 
 cli
 	.command('', 'Run the initialization or migration')

--- a/packages/eslint-config/src/cli/run.ts
+++ b/packages/eslint-config/src/cli/run.ts
@@ -13,9 +13,6 @@ import { updateVscodeSettings } from './stages/update-vscode-settings';
 import type { FrameworkOption, PromptResult } from './types';
 import { isGitClean } from './utils';
 
-/**
- * CLI options for `@mheob/eslint-config`
- */
 export interface CliRunOptions {
 	/**
 	 * Use the framework template for optimal customization: vue / react / svelte / astro
@@ -52,7 +49,7 @@ export async function run(options: CliRunOptions = {}): Promise<void> {
 		result = (await p.group(
 			{
 				uncommittedConfirmed: () => {
-					if (argumentSkipPrompt || isGitClean()) return Promise.resolve(true);
+					if (isGitClean()) return Promise.resolve(true);
 
 					return p.confirm({
 						initialValue: false,
@@ -60,6 +57,7 @@ export async function run(options: CliRunOptions = {}): Promise<void> {
 							'There are uncommitted changes in the current repository, are you sure to continue?',
 					});
 				},
+
 				frameworks: ({ results }) => {
 					const isArgumentTemplateValid =
 						typeof argumentTemplate === 'string' &&

--- a/packages/eslint-config/src/cli/run.ts
+++ b/packages/eslint-config/src/cli/run.ts
@@ -1,0 +1,110 @@
+/* eslint-disable perfectionist/sort-objects */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import * as p from '@clack/prompts';
+import c from 'ansis';
+
+import { frameworkOptions, frameworks } from './constants';
+import { updateEslintFiles } from './stages/update-eslint-files';
+import { updatePackageJson } from './stages/update-package-json';
+import { updateVscodeSettings } from './stages/update-vscode-settings';
+import type { FrameworkOption, PromptResult } from './types';
+import { isGitClean } from './utils';
+
+/**
+ * CLI options for `@mheob/eslint-config`
+ */
+export interface CliRunOptions {
+	/**
+	 * Use the framework template for optimal customization: vue / react / svelte / astro
+	 */
+	frameworks?: string[];
+	/**
+	 * Skip prompts and use default values
+	 */
+	yes?: boolean;
+}
+
+export async function run(options: CliRunOptions = {}): Promise<void> {
+	const argumentSkipPrompt = Boolean(process.env.SKIP_PROMPT) || options.yes;
+	const argumentTemplate = <FrameworkOption[]>(
+		options.frameworks?.map(m => m?.trim()).filter(Boolean)
+	);
+
+	const configFileExists = (fileNames: string[]): boolean =>
+		fileNames.some(fileName => fs.existsSync(path.join(process.cwd(), fileName)));
+
+	if (configFileExists(['eslint.config.js', 'eslint.config.mjs'])) {
+		p.log.warn(c.yellow`eslint.config.js already exists, migration wizard exited.`);
+		return process.exit(1);
+	}
+
+	// Set default value for promptResult if `argSkipPrompt` is enabled
+	let result: PromptResult = {
+		frameworks: argumentTemplate ?? [],
+		uncommittedConfirmed: false,
+		updateVscodeSettings: true,
+	};
+
+	if (!argumentSkipPrompt) {
+		result = (await p.group(
+			{
+				uncommittedConfirmed: () => {
+					if (argumentSkipPrompt || isGitClean()) return Promise.resolve(true);
+
+					return p.confirm({
+						initialValue: false,
+						message:
+							'There are uncommitted changes in the current repository, are you sure to continue?',
+					});
+				},
+				frameworks: ({ results }) => {
+					const isArgumentTemplateValid =
+						typeof argumentTemplate === 'string' &&
+						Boolean(frameworks.includes(<FrameworkOption>argumentTemplate));
+
+					if (!results.uncommittedConfirmed || isArgumentTemplateValid) return;
+
+					const message =
+						!isArgumentTemplateValid && argumentTemplate
+							? `"${argumentTemplate}" isn't a valid template. Please choose from below: `
+							: 'Select a framework:';
+
+					return p.multiselect<FrameworkOption>({
+						message: c.reset(message),
+						options: frameworkOptions,
+						required: false,
+					});
+				},
+
+				updateVscodeSettings: ({ results }) => {
+					if (!results.uncommittedConfirmed) return;
+
+					return p.confirm({
+						initialValue: true,
+						message: 'Update .vscode/settings.json for better VS Code experience?',
+					});
+				},
+			},
+			{
+				onCancel: () => {
+					p.cancel('Operation cancelled.');
+					process.exit(0);
+				},
+			},
+		)) as PromptResult;
+
+		if (!result.uncommittedConfirmed) return process.exit(1);
+	}
+
+	await updatePackageJson(result);
+	await updateEslintFiles(result);
+	await updateVscodeSettings(result);
+
+	p.log.success(c.green`Setup completed`);
+	p.outro(
+		`Now you can update the dependencies by run ${c.blue('pnpm install')} and run ${c.blue('eslint --fix')}\n`,
+	);
+}

--- a/packages/eslint-config/src/cli/stages/update-eslint-files.ts
+++ b/packages/eslint-config/src/cli/stages/update-eslint-files.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import * as p from '@clack/prompts';
+import c from 'ansis';
+// @ts-expect-error missing types
+import parse from 'parse-gitignore';
+
+import type { PromptResult } from '../types';
+import { getEslintConfigContent } from '../utils';
+
+export async function updateEslintFiles(result: PromptResult): Promise<void> {
+	const cwd = process.cwd();
+	const pathESLintIgnore = path.join(cwd, '.eslintignore');
+
+	const configFileName = 'eslint.config.mjs';
+	const pathFlatConfig = path.join(cwd, configFileName);
+
+	const eslintIgnores: string[] = [];
+	if (fs.existsSync(pathESLintIgnore)) {
+		p.log.step(c.cyan`Migrating existing .eslintignore`);
+		const content = await fsp.readFile(pathESLintIgnore, 'utf8');
+		const parsed = parse(content);
+		const globs = parsed.globs();
+
+		for (const glob of globs) {
+			if (glob.type === 'ignore') eslintIgnores.push(...glob.patterns);
+			else if (glob.type === 'unignore')
+				eslintIgnores.push(...glob.patterns.map((pattern: string) => `!${pattern}`));
+		}
+	}
+
+	const configLines: string[] = [];
+
+	if (eslintIgnores.length > 0) configLines.push(`ignores: ${JSON.stringify(eslintIgnores)},`);
+
+	for (const framework of result.frameworks) configLines.push(`${framework}: true,`);
+
+	const mainConfig = configLines.map(i => `  ${i}`).join('\n');
+	const additionalConfig: string[] = [];
+
+	const eslintConfigContent: string = getEslintConfigContent(mainConfig, additionalConfig);
+
+	await fsp.writeFile(pathFlatConfig, eslintConfigContent);
+	p.log.success(c.green`Created ${configFileName}`);
+
+	const files = fs.readdirSync(cwd);
+	const legacyConfig: string[] = [];
+	for (const file of files) {
+		if (/eslint|prettier/.test(file) && !/eslint\.config\./.test(file)) legacyConfig.push(file);
+	}
+
+	if (legacyConfig.length > 0)
+		p.note(c.dim(legacyConfig.join(', ')), 'You can now remove those files manually');
+}

--- a/packages/eslint-config/src/cli/stages/update-package-json.ts
+++ b/packages/eslint-config/src/cli/stages/update-package-json.ts
@@ -1,0 +1,44 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import * as p from '@clack/prompts';
+import c from 'ansis';
+
+import { version } from '../../../package.json';
+import { dependenciesMap } from '../constants';
+import type { PromptResult } from '../types';
+import { versionsMap } from '../versions-map.generated';
+
+export async function updatePackageJson(result: PromptResult): Promise<void> {
+	const cwd = process.cwd();
+
+	const pathPackageJSON = path.join(cwd, 'package.json');
+
+	p.log.step(c.cyan`Bumping @antfu/eslint-config to v${version}`);
+
+	const pkgContent = await fsp.readFile(pathPackageJSON, 'utf8');
+	// eslint-disable-next-line ts/no-explicit-any
+	const pkg: Record<string, any> = JSON.parse(pkgContent);
+
+	pkg.devDependencies ??= {};
+	pkg.devDependencies['@antfu/eslint-config'] = `^${version}`;
+	pkg.devDependencies.eslint ??= versionsMap.eslint;
+
+	const addedPackages: string[] = [];
+
+	for (const framework of result.frameworks) {
+		const deps = dependenciesMap[framework];
+		if (deps) {
+			for (const f of deps) {
+				pkg.devDependencies[f] = versionsMap[f as keyof typeof versionsMap];
+				addedPackages.push(f);
+			}
+		}
+	}
+
+	if (addedPackages.length > 0) p.note(c.dim(addedPackages.join(', ')), 'Added packages');
+
+	await fsp.writeFile(pathPackageJSON, JSON.stringify(pkg, null, 2));
+	p.log.success(c.green`Changes wrote to package.json`);
+}

--- a/packages/eslint-config/src/cli/stages/update-vscode-settings.ts
+++ b/packages/eslint-config/src/cli/stages/update-vscode-settings.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+import * as p from '@clack/prompts';
+import { green } from 'ansis';
+
+import { vscodeSettingsString } from '../constants';
+import type { PromptResult } from '../types';
+
+export async function updateVscodeSettings(result: PromptResult): Promise<void> {
+	const cwd = process.cwd();
+
+	if (!result.updateVscodeSettings) return;
+
+	const dotVscodePath: string = path.join(cwd, '.vscode');
+	const settingsPath: string = path.join(dotVscodePath, 'settings.json');
+
+	if (!fs.existsSync(dotVscodePath)) await fsp.mkdir(dotVscodePath, { recursive: true });
+
+	if (!fs.existsSync(settingsPath)) {
+		await fsp.writeFile(settingsPath, `{${vscodeSettingsString}}\n`, 'utf8');
+		p.log.success(green`Created .vscode/settings.json`);
+	} else {
+		let settingsContent = await fsp.readFile(settingsPath, 'utf8');
+
+		settingsContent = settingsContent.trim().replace(/\s*\}$/, '');
+		settingsContent += settingsContent.endsWith(',') || settingsContent.endsWith('{') ? '' : ',';
+		settingsContent += `${vscodeSettingsString}}\n`;
+
+		await fsp.writeFile(settingsPath, settingsContent, 'utf8');
+		p.log.success(green`Updated .vscode/settings.json`);
+	}
+}

--- a/packages/eslint-config/src/cli/types.ts
+++ b/packages/eslint-config/src/cli/types.ts
@@ -1,0 +1,13 @@
+export interface PromptItem<T> {
+	hint?: string;
+	label: string;
+	value: T;
+}
+
+export type FrameworkOption = 'astro' | 'react' | 'svelte' | 'vue';
+
+export interface PromptResult {
+	frameworks: FrameworkOption[];
+	uncommittedConfirmed: boolean;
+	updateVscodeSettings: unknown;
+}

--- a/packages/eslint-config/src/cli/utils.ts
+++ b/packages/eslint-config/src/cli/utils.ts
@@ -1,0 +1,32 @@
+import { execSync } from 'node:child_process';
+
+/**
+ * Checks if the current working directory is clean according to Git.
+ *
+ * @returns `true` if the current working directory is clean, `false` otherwise.
+ */
+export function isGitClean(): boolean {
+	try {
+		execSync('git diff-index --quiet HEAD --');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Generates the content for an ESLint configuration file.
+ *
+ * @param mainConfig - The main configuration object.
+ * @param additionalConfigs - Optional additional configurations to be merged.
+ * @returns The generated ESLint configuration content.
+ */
+export function getEslintConfigContent(mainConfig: string, additionalConfigs?: string[]): string {
+	return `
+import defaultConfig from '@mheob/eslint-config'
+
+export default defaultConfig({
+${mainConfig}
+}${additionalConfigs?.map(config => `,{\n${config}\n}`)})
+`.trimStart();
+}

--- a/packages/eslint-config/src/cli/versions-map.generated.ts
+++ b/packages/eslint-config/src/cli/versions-map.generated.ts
@@ -1,0 +1,11 @@
+export const versionsMap = {
+	'@eslint-react/eslint-plugin': '^1.45.3',
+	'astro-eslint-parser': '^1.2.2',
+	eslint: 'catalog:',
+	'eslint-plugin-astro': '^1.3.1',
+	'eslint-plugin-react-hooks': '^5.2.0',
+	'eslint-plugin-react-refresh': '^0.4.19',
+	'eslint-plugin-svelte': '^3.5.1',
+	'prettier-plugin-astro': '^0.14.1',
+	'svelte-eslint-parser': '^1.1.2',
+};

--- a/packages/eslint-config/src/configs/disables.ts
+++ b/packages/eslint-config/src/configs/disables.ts
@@ -17,6 +17,7 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
 			rules: {
 				'antfu/no-top-level-await': 'off',
 				'no-console': 'off',
+				'unicorn/no-process-exit': 'off',
 			},
 		},
 		{

--- a/packages/eslint-config/src/configs/unicorn.ts
+++ b/packages/eslint-config/src/configs/unicorn.ts
@@ -34,6 +34,7 @@ export async function unicorn(options: OptionsOverrides = {}): Promise<TypedFlat
 							i: false,
 							idx: false,
 							params: false,
+							pkg: false,
 							props: false,
 							temp: false,
 							tmp: false,

--- a/packages/eslint-config/tsup.config.ts
+++ b/packages/eslint-config/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig(options => ({
 	dts: true,
-	entry: ['src/index.ts'],
+	entry: ['src/index.ts', 'src/cli.ts'],
 	format: ['esm'],
 	minify: !options.watch,
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,12 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.1.42
         version: 1.1.42(@typescript-eslint/utils@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.1(@types/node@22.14.1)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
+      ansis:
+        specifier: ^3.17.0
+        version: 3.17.0
+      cac:
+        specifier: ^6.7.14
+        version: 6.7.14
       eslint-config-flat-gitignore:
         specifier: ^2.1.0
         version: 2.1.0(eslint@9.24.0(jiti@2.4.2))

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
 	"$schema": "https://turbo.build/schema.json",
 	"tasks": {
 		"build": {
-			"dependsOn": ["typegen", "^build"],
+			"dependsOn": ["gen", "^build"],
 			"outputs": []
 		},
 		"clean": {
@@ -11,7 +11,14 @@
 		"lint": {
 			"outputs": []
 		},
+		"gen": {
+			"dependsOn": ["typegen", "versiongen"],
+			"outputs": []
+		},
 		"typegen": {
+			"outputs": []
+		},
+		"versiongen": {
 			"outputs": []
 		}
 	}


### PR DESCRIPTION
Resolves #252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CLI tool for guided ESLint configuration, supporting framework selection (Vue, React, Svelte, Astro) and migration assistance.
	- Enhanced VS Code support with updated ESLint settings that now include additional languages and customized stylistic rules.
	- Added script commands to simplify project generation and automated versioning.

- **Documentation**
	- Revised setup instructions to feature a user-friendly Starter Wizard for effortless configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->