### PR TITLE
fix(eslint): deactivate `react/no-leaked-conditional-rendering` rule

### DIFF
--- a/.changeset/fluffy-emus-burn.md
+++ b/.changeset/fluffy-emus-burn.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': patch
+---
+
+deactivate `react/no-leaked-conditional-rendering` rule for now; should be added again after the `parserOptions` issue is done

--- a/packages/eslint-config/src/configs/javascript.ts
+++ b/packages/eslint-config/src/configs/javascript.ts
@@ -54,7 +54,7 @@ export async function javascript(
 				'no-class-assign': 'error',
 				'no-compare-neg-zero': 'error',
 				'no-cond-assign': ['error', 'always'],
-				'no-console': ['warn', { allow: ['warn', 'error'] }],
+				'no-console': ['warn', { allow: ['info', 'warn', 'error'] }],
 				'no-const-assign': 'error',
 				'no-control-regex': 'error',
 				'no-debugger': 'error',

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -169,7 +169,7 @@ export async function react(
 				'react/no-duplicate-key': 'warn',
 				'react/no-forward-ref': 'warn',
 				'react/no-implicit-key': 'warn',
-				'react/no-leaked-conditional-rendering': 'warn',
+				// 'react/no-leaked-conditional-rendering': 'warn', // deactivated because it is not working (parserOptions issue)
 				'react/no-missing-key': 'error',
 				'react/no-misused-capture-owner-stack': 'error',
 				'react/no-nested-component-definitions': 'error',

--- a/packages/eslint-config/src/factory.ts
+++ b/packages/eslint-config/src/factory.ts
@@ -107,8 +107,7 @@ export function mheob(
 	if (isInEditor == null) {
 		isInEditor = isInEditorEnv();
 		if (isInEditor)
-			// eslint-disable-next-line no-console
-			console.log('[@mheob/eslint-config] Detected running in editor, some rules are disabled.');
+			console.info('[@mheob/eslint-config] Detected running in editor, some rules are disabled.');
 	}
 
 	const configs: Awaitable<TypedFlatConfigItem[]>[] = [];
@@ -182,6 +181,7 @@ export function mheob(
 	if (options.react ?? false) {
 		configs.push(
 			react({
+				...typescriptOptions,
 				overrides: getOverrides(options, 'react'),
 				tsconfigPath,
 			}),


### PR DESCRIPTION
This fix temporarily resolves the following issue:

> Error while loading rule 'react/no-leaked-conditional-rendering': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file. See https://typescript-eslint.io/getting-started/typed-linting for enabling linting with type information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled the ESLint rule for conditional rendering in React due to a temporary issue.
- **Refactor**
	- Updated logging to use `console.info` for editor environment messages.
	- Adjusted internal configuration to include all TypeScript-related options in React settings.
- **Style**
	- Allowed the use of `console.info` in addition to `warn` and `error` without triggering ESLint warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->