### PR TITLE
feat(eslint): add custom sort (id on top)

### DIFF
--- a/.changeset/angry-cloths-feel.md
+++ b/.changeset/angry-cloths-feel.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+add custom sort (id on top)

--- a/packages/eslint-config/src/configs/perfectionist.ts
+++ b/packages/eslint-config/src/configs/perfectionist.ts
@@ -1,5 +1,35 @@
 import { pluginPerfectionist } from '../plugins';
+import type {
+	PerfectionistSortInterfaces,
+	PerfectionistSortObjects,
+	PerfectionistSortObjectTypes,
+} from '../typegen';
 import type { TypedFlatConfigItem } from '../types';
+
+type PerfectionistSortCustom =
+	| PerfectionistSortInterfaces[number]
+	| PerfectionistSortObjects[number]
+	| PerfectionistSortObjectTypes[number];
+
+const customSort = {
+	customGroups: [
+		{
+			elementNamePattern: '^id$',
+			groupName: 'top',
+			selector: 'property',
+			type: 'natural',
+		},
+	],
+	groups: [
+		'top',
+		['multiline-optional-method', 'optional-multiline-method'],
+		'method',
+		['multiline-optional-member', 'optional-multiline-member'],
+		'member',
+		'unknown',
+	],
+	type: 'natural',
+} satisfies PerfectionistSortCustom;
 
 /**
  * Optional perfectionist plugin for props and items sorting.
@@ -19,10 +49,7 @@ export async function perfectionist(): Promise<TypedFlatConfigItem[]> {
 		{
 			name: 'mheob/perfectionist/rules',
 			rules: {
-				'perfectionist/sort-array-includes': [
-					'error',
-					{ groupKind: 'literals-first', type: 'natural' },
-				],
+				'perfectionist/sort-array-includes': ['error', { groups: ['literal'], type: 'natural' }],
 				'perfectionist/sort-classes': ['error', { type: 'natural' }],
 				'perfectionist/sort-enums': ['error', { type: 'natural' }],
 				'perfectionist/sort-exports': ['error', { type: 'natural' }],
@@ -44,7 +71,7 @@ export async function perfectionist(): Promise<TypedFlatConfigItem[]> {
 						type: 'natural',
 					},
 				],
-				'perfectionist/sort-interfaces': ['error', { type: 'natural' }],
+				'perfectionist/sort-interfaces': ['error', customSort],
 				'perfectionist/sort-intersection-types': ['error', { type: 'natural' }],
 				'perfectionist/sort-jsx-props': [
 					'error',
@@ -53,8 +80,18 @@ export async function perfectionist(): Promise<TypedFlatConfigItem[]> {
 				'perfectionist/sort-maps': ['error', { type: 'natural' }],
 				'perfectionist/sort-named-exports': ['error', { type: 'natural' }],
 				'perfectionist/sort-named-imports': ['error', { type: 'natural' }],
-				'perfectionist/sort-object-types': ['error', { type: 'natural' }],
-				'perfectionist/sort-objects': ['error', { type: 'natural' }],
+				'perfectionist/sort-object-types': ['error', customSort],
+				'perfectionist/sort-objects': [
+					'error',
+					{
+						customGroups: customSort.customGroups,
+						groups: [
+							'top',
+							['multiline-method', 'method', 'multiline-member', 'member', 'unknown'],
+						],
+						type: customSort.type,
+					},
+				],
 				'perfectionist/sort-union-types': ['error', { type: 'natural' }],
 			},
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom sorting feature that ensures properties named "id" are placed at the top when sorting interfaces, object types, and objects.

- **Refactor**
  - Updated sorting configurations for improved consistency and explicit grouping, including adjustments to array includes sorting behavior.

- **Chores**
  - Added documentation for the new version update and sorting feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->