### PR TITLE
feat(eslint): update allow exports `react-router`

### DIFF
--- a/.changeset/warm-eels-sniff.md
+++ b/.changeset/warm-eels-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mheob/eslint-config': minor
+---
+
+update allowed exports for `react-router`

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -133,7 +133,17 @@ export async function react(
 									]
 								: []),
 							...(isUsingRemix || isUsingReactRouter
-								? ['meta', 'links', 'headers', 'loader', 'action']
+								? [
+										'meta',
+										'links',
+										'headers',
+										'loader',
+										'action',
+										'clientLoader',
+										'clientAction',
+										'handle',
+										'shouldRevalidate',
+									]
 								: []),
 						],
 					},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to expand the list of allowed export names for React Router and Remix environments in the ESLint rules.
- **Documentation**
  - Added a changeset to record a minor version update reflecting the configuration change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->