### PR TITLE
fix(tsconfig): remove stray react include

### DIFF
--- a/.changeset/tsconfig-remove-react-include.md
+++ b/.changeset/tsconfig-remove-react-include.md
@@ -1,0 +1,7 @@
+---
+'@mheob/tsconfig': patch
+---
+
+Remove the hardcoded `include: ["src"]` from the `react` preset. Every other preset (`base`, `commonjs`, `esm`, `astro`) leaves
+`include` unset so consumers control which files are compiled; `react` picked up a stray `src`-only restriction during the
+TypeScript 7 update, which would silently exclude any consumer project that doesn't keep its sources under `src`.

--- a/packages/tsconfig/react.json
+++ b/packages/tsconfig/react.json
@@ -16,6 +16,5 @@
 		"isolatedModules": true,
 		"noEmit": true,
 		"jsx": "react-jsx"
-	},
-	"include": ["src"]
+	}
 }


### PR DESCRIPTION
## Summary

Remove the hardcoded `include: ["src"]` that ended up in the `react` preset (`@mheob/tsconfig`)
during the TypeScript 7 update.

## Changes

- Drop `include: ["src"]` from `packages/tsconfig/react.json`.
- Add a `patch` changeset for `@mheob/tsconfig`.

## Motivation

Every other preset (`base`, `commonjs`, `esm`, `astro`) leaves `include` unset so consumers control
which files get compiled. The `react` preset picked up a stray `src`-only restriction as part of the
prior TypeScript 7 fix (#394), which would silently exclude any consumer project that doesn't keep
its sources under `src`. This restores the preset to the same extensible behavior as the others.