### PR TITLE
chore: switch Markdown formatting to proseWrap never

### DIFF
--- a/.changeset/markdown-prose-wrap-never.md
+++ b/.changeset/markdown-prose-wrap-never.md
@@ -1,0 +1,5 @@
+---
+'@mheob/oxfmt-config': minor
+---
+
+Format Markdown with `proseWrap: 'never'` instead of a `printWidth` of `130`. Prose is now kept on a single line per paragraph, which keeps diffs on documentation changes minimal. Widen the `oxfmt` peer range to `>=0.62.0 <1.0.0`.

--- a/.changeset/update-workspace-dependencies.md
+++ b/.changeset/update-workspace-dependencies.md
@@ -1,0 +1,8 @@
+---
+'@mheob/commitlint-config': patch
+'@mheob/oxfmt-config': patch
+'@mheob/oxlint-config': minor
+'@mheob/internal': patch
+---
+
+Update dependencies across the workspace, including `oxfmt` (^0.62.0), `oxlint` (^1.77.0), `tsdown` (^0.22.14), `@types/node` (^26.1.2), `turbo` (^2.10.8), `eslint-plugin-better-tailwindcss` (^4.7.0), `eslint-plugin-storybook` (^10.5.6), and `eslint-plugin-yml` (^3.7.0). Bump the `oxlint` peer range in `oxlint-config` to `^1.77.0`.

--- a/.claude/skills/gitbutler/SKILL.md
+++ b/.claude/skills/gitbutler/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: but
+version: 0.22.0
+description: "Commit, push, branch, and manage version control with GitButler. Use for commits, selective dirty-file or hunk commits, branches, diffs, PRs, history edits, squashes, amends, undo, merge, apply, and unapply. For selected dirty files or hunks, inspect with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview; use `but status -fv` when file/hunk IDs or per-commit file details matter. Replaces git write commands."
+author: GitButler Team
+---
+
+# GitButler CLI Skill
+
+Use GitButler CLI (`but`) as the default version-control interface.
+
+## Start Here
+
+Choose the narrowest first command by task; avoid ritual status checks:
+
+```bash
+# Selected dirty files/hunks:
+but diff
+
+# Commit order, branch/stack placement, conflict overview:
+but status
+
+# File/hunk IDs, per-commit files, amend/split details:
+but status -fv
+
+# Details for one known branch or commit:
+but show <id>
+```
+
+Do not run plain `but status` and then `but status -fv` unless the compact output lacks file/hunk details needed for the task.
+
+For "commit just/only/specific changes on a new branch", use the fast path:
+
+```bash
+but diff
+but commit -b <branch> -m "<msg>" <id> <id>
+```
+
+`but commit -b <branch> ...` creates the branch when it does not exist and prints the created commit. Do not run a separate `but branch new`, status command, or verification diff unless the task needs workspace information that the result does not provide.
+
+## IDs
+
+The first token on each `but diff` / `but status` line is that line's ID — pass it to commands as-is; never hardcode or invent IDs. IDs may be a single character when unambiguous; copy them exactly from command output.
+
+- Changes and sources are **positional, space-separated** IDs (`but commit -b feat -m "msg" qs:5 uo`). A hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--changes` / `--hunk` / `--ids`, pass a line range, or comma-separate IDs — `nk,pn` is parsed as one ID and fails.
+- `but diff` is the exception: it accepts at most **one** target. Bare `but diff` shows all uncommitted files; inspect committed files or other entities one target at a time — never `but diff <id> <id>`.
+- A committed file is `<commit-id>:<file-id>` (e.g. `uyr:n`, shown under each commit). `zz` means the uncommitted area.
+- Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
+- File/hunk IDs copied from one diff read generally remain usable across chained commits; branch IDs are stable. If an ID stops resolving, re-read `but status`/`but diff` and retry.
+
+**Chaining:** mutation output is concise by default, so you may chain mutations with `&&` off one inspection read. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Chaining `but uncommit <id> && but diff` is safe because bare `diff` needs no ID from the uncommit output.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
+2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
+3. Branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch. `push` and mutations (`commit`, `amend`, `squash`, `uncommit`, `reword`, `move`) refuse landed branches and commits, `absorb` skips them with a notice, and `commit` skips them when picking a default target.
+4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
+5. Prefer this skill and `references/reference.md` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
+
+## Command Patterns
+
+- Commit: `but commit -b <branch> -m "<msg>" <id> <id>` — `-b <branch>` creates the branch if it does not exist
+- Commit everything uncommitted: `but commit -b <branch> -m "<msg>"` (omit the IDs)
+- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first)
+- Commit at a specific history position: `--above <commit-or-branch>` or `--below <commit-or-branch>` instead of `-b`
+- Only one targeting flag (`-b` / `--above` / `--below`) per command. Targeting is **required** when more than one **stack** is applied; without it `but commit` fails with "Unclear where to commit. Found more than one stack". Several branches stacked together count as one stack — an untargeted commit then silently lands on the stack's top branch, so pass `-b` whenever the branch matters.
+- Always pass `-m "<msg>"` (or `--no-message`) to `but commit`, and to `but squash` whenever its sources are commits or branches — those compose a new message, and without a flag an editor opens and blocks. Squash sources that are uncommitted or committed files reuse the target's message and need no flag; squashing into `zz` rejects message flags outright.
+- Amend: `but amend -t <commit-or-branch> <file-or-hunk-id> <file-or-hunk-id>` — a branch target resolves to its newest commit
+- Uncommit: `but uncommit <commit-id>` (whole commit) or `but uncommit <commit-id>:<file-id>` (one committed file); multiple committed-file sources in one call must come from one commit
+- Insert empty commit: `but commit --empty -b <branch> -m "<msg>"`
+- Squash commits: `but squash <source-commit-id> [<source-commit-id>...] -t <target-commit-id> -m "<msg>"`
+- Squash a whole branch into one commit: `but squash <branch> -m "<msg>"` (no `-t`)
+- Reorder commits: `but move <commit-id> --below <commit-id>` (`--above` for the other direction; **commit IDs**, not branch names)
+- Reorder a block: `but move <commit-id> <commit-id> --below <following-commit-id>` or `--above <preceding-commit-id>` (both anchors accept multiple space-separated sources)
+- Move commit to branch top: `but move <commit-id> -b <branch>`
+- Stack branches: `but move <branch> --above <target-branch>` (**branch names or branch CLI IDs**)
+- Tear off a branch: `but move <branch> --unstack`
+- Discard: `but discard <id> [<id>...]` — accepts branches, commits, committed files, uncommitted files/hunks, or `zz` for all uncommitted changes
+- Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
+- Pull (update workspace from the target): `but pull` — the output reports the result; `but pull --check` previews without updating when a preview is actually needed
+- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
+
+## Task Recipes
+
+### Update workspace from main
+
+For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
+
+1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
+2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, then `but resolve finish`. Its result gives the current ID of the next conflict. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+
+`but pull --check` answers "would this conflict?" without updating. Do not use it as a routine
+preflight; use it when the user asks for a preview, repository policy requires one, or other agents'
+branches may move.
+
+Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them: `but commit -b <branch> -m "wip" <ids>`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
+
+### Commit selected files or hunks
+
+1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
+2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
+3. `but commit -b <branch> -m "<msg>" <id1> <id2>` — the branch is created if it does not exist, so no prior `but branch new` is needed.
+4. When the task requires knowing which changes remain, add `--status-after`; otherwise the created-commit result is sufficient.
+
+Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit those IDs, then restore the leftover lines so they remain uncommitted.
+
+### Amend into existing commit
+
+1. `but status -fv` (or `but show <branch-id>`) — locate file/hunk IDs and target commit IDs.
+2. `but amend -t <commit-id> <id> <id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with `--status-after` to get fresh refs.
+
+### Split an existing commit
+
+Use this when an existing commit should be replaced by selected smaller commits.
+
+1. `but status -fv` when you need the source commit, branch name, or placement anchor.
+2. `but uncommit <source-commit-id> && but diff` in one shell call exposes the commit's changes and prints the resulting file and hunk IDs.
+3. Pick replacement contents from that dirty diff, not from the old committed diff.
+4. Determine the requested chronological order from the user's wording, then create the replacement commits oldest-first by chaining `but commit` calls. Do not reverse that order to match `but status`, which displays commits newest-first. `-b <branch>` puts each new commit at the TOP of that branch — if the split commit had commits above it, the replacements now sit above those preserved commits.
+5. **If commits from that branch must stay ABOVE the replacements, put the preserved block back on top instead of fighting anchors.** Do not anchor with `--above <top>`/`--below <top>` (sha/`#N` anchors go stale as each insert rewrites history). Move the block together so its internal order stays intact: append `&& but move <preserved-id> [<preserved-id>...] -b <branch>` to the commit chain. Change-ID refs from step 1 stay valid; wait for fresh output first if any preserved ref is sha-based or `#N`-suffixed.
+6. Leave unwanted changes uncommitted. Replacements created oldest-first appear newest-first in status — that is correct; do not reorder them. Add `--status-after` to the final mutation when you need to inspect the resulting order.
+
+### Reorder commits
+
+`but status` displays commits newest/top first, while task specs often list history oldest to newest — translate before moving.
+
+1. `but status` once to get commit IDs (use `-fv` only if you also need file details).
+2. `but move <source> --below <target-commit>` places source immediately below target in `but status` (older in oldest-to-newest history). `--above` places it immediately above (newer). `but move <source> -b <branch>` moves it to branch top/newest.
+3. For an adjacent block, run ONE move, anchored either way: `but move <block-id> <block-id> --below <following-commit-id>` or `but move <block-id> <block-id> --above <preceding-commit-id>`. Pick an anchor outside the block; source order does not matter and the block keeps its internal order. Add `--status-after` when you need to inspect the resulting order; do not move the anchor or block members again.
+4. For other reorders, make the smallest set of moves.
+
+### Squash commits
+
+1. `but status` for commit IDs and order.
+2. Name the sources positionally and the result/target commit with `-t`: `but squash <source> [<source>...] -t <target> -m "<new message>"`.
+3. To collapse an entire branch into one commit, pass just the branch and no `-t`: `but squash <branch> -m "<new message>"`.
+4. Multiple independent groups may run in sequence off one status read (targets keep their change-ID refs); prefer newer/top groups first. Take fresh refs only when a ref is sha-based or `#N`-suffixed.
+5. Add `--status-after` to the final squash when you need to inspect the resulting history; do not re-verify with a separate status.
+
+### Stack existing branches
+
+To make one existing branch depend on another: `but move <child-branch> --above <parent-branch>` (branch **names** or branch CLI IDs — commit reordering uses commit IDs). To unstack: `but move <branch> --unstack`.
+
+**DO NOT** stack via `uncommit` + `branch delete` + `branch new -a` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
+
+### Create or manage pull requests
+
+`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
+
+For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
+
+### Dependency conflict with another branch
+
+Changes that build on another branch's commits cannot land on an independent branch. `but commit` and `but amend` fail atomically ("Cannot commit: N changes could not be applied"), naming the branch and commit each rejected change depends on — nothing is committed and no `-b` branch is created.
+
+When there is a single dependency branch, the error's Hint gives the exact recovery command: `but move <your-branch> --above <dependency-branch>` to stack an existing branch on its dependency, or `but branch new <name> --anchor <dependency-branch>` when the target branch didn't exist yet. Run it, then retry the original command. When the error names dependencies without a Hint (several dependency branches, or the dependency is on the target branch itself), run `but status -fv` to see where the dependent commits live before choosing a placement.
+
+If that recovery command fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
+
+### Resolve conflicted commits (after pull, move, or reorder)
+
+**NEVER use `git add`, `git commit`, `git checkout --theirs/--ours`, or any git write command during resolution.** Only `but resolve` commands plus direct file edits.
+
+1. Find conflicted commits: history-editing commands (`move`, `discard`, …) warn about newly conflicted commits in their output, and the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
+2. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
+3. **Edit the files** to remove every conflict marker — `<<<<<<<`, `|||||||` (the common-ancestor section), `=======` and `>>>>>>>` — and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
+4. `but resolve finish` reports leftover markers, surviving uncommitted changes, every remaining conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status.
+5. Repeat for remaining conflicted commits, oldest first — finishing a lower commit rebases the ones above it.
+
+### Conflicts in uncommitted files
+
+`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Choose the desired contents or delete the file, then `git add -- <path>` to mark it resolved (the one permitted `git add`).
+
+## Git-to-But Map
+
+| git | but |
+|---|---|
+| `git status` | `but status` for branch/stack/commit overview; `but status -fv` for file/hunk details; `but diff` for selected dirty changes |
+| `git add` + `git commit` | `but commit -b <branch> -m ... <ids>` |
+| `git checkout -b` + commit | `but commit -b <new-branch> -m ... <ids>` |
+| `git push` | `but push <branch-name>` |
+| `git rebase -i` | `but move`, `but squash`, `but reword` |
+| `git rebase --onto` | `but move <branch> --above <new-base>` |
+| `git checkout -- <file>` / `git restore` | `but discard <id>` |
+| `git cherry-pick` | `but pick` |
+| `gh pr create` | `but pr new <branch-id> -m "Title..."` |
+
+## Notes
+
+- Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
+- If `but` prints an `AGENT ACTION REQUIRED` skill warning, run the suggested command once, then reload/use the GitButler skill. If it repeats, report it instead of retrying.
+- For command syntax and flags: `references/reference.md`
+- For workspace model: `references/concepts.md`
+- For workflow examples: `references/examples.md`

--- a/.claude/skills/gitbutler/references/concepts.md
+++ b/.claude/skills/gitbutler/references/concepts.md
@@ -1,0 +1,306 @@
+# GitButler CLI Key Concepts
+
+Deep dive into GitButler's conceptual model and philosophy.
+
+## The Workspace Model
+
+### Traditional Git: Serial Branching
+
+```
+main ──┬── feature-a (checkout here, work, commit, checkout back)
+       └── feature-b (checkout here, work, commit, checkout back)
+```
+
+- Work on ONE branch at a time
+- Switch contexts with `git checkout`
+- Changes are isolated by branch
+
+### GitButler: Parallel Stacks
+
+```
+workspace (gitbutler/workspace)
+  ├─ feature-a (applied, merged into workspace)
+  ├─ feature-b (applied, merged into workspace)
+  └─ feature-c (unapplied, not in workspace)
+```
+
+- Work on MULTIPLE branches simultaneously
+- No context switching - all applied branches merged in working directory
+- Changes are ASSIGNED to branches, not isolated by checkout
+
+### Key Implications
+
+1. **No `git checkout`**: You don't switch between branches. All applied branches exist simultaneously in your workspace.
+
+2. **The `gitbutler/workspace` branch**: A merge commit containing all applied stacks. Don't interact with it directly - use `but` commands.
+
+3. **Applied vs Unapplied**: Control which branches are active:
+   - Applied branches: In your working directory
+   - Unapplied branches: Exist but not active
+   - Use `but apply`/`but unapply` to control
+
+## CLI IDs: Short Identifiers
+
+Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status`.
+
+```
+Commits:    1, kyn, mpq#0  (short change-ID prefix when the commit has one, sha prefix otherwise;
+                             a #N suffix disambiguates commits sharing a change ID)
+Branches:   fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
+                             falls back to auto-generated ID if no unique substring exists)
+Files:      g, qs, uo      (derived from the file path, long enough to be unique)
+Hunks:      g:5, uo:d      (<file-id>:<hunk-id>; the hunk part is derived from the hunk's content)
+Committed files: kyn:n     (<commit-id>:<file-id>, shown under each commit in `but status -fv`)
+Stacks:     m0, n0          (auto-generated, 2–3 chars)
+```
+
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short, variable-length, and unique within your current workspace context. Commits, files, and hunks may use a single character when that is unambiguous.
+
+**Reading status output:** the first token on each line is that line's ID. Verbose commit lines append an informational `(sha …)` after the timestamp — it changes on every amend; do not pass it to commands.
+
+**Stability:** File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are change-ID prefixes when the commit has a change ID and sha prefixes otherwise. Change-ID refs survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); sha refs and `#N`-suffixed refs do not — a stale sha can silently resolve to the wrong commit. History edits may run in sequence off one status read when every ref involved is a change-ID ref; otherwise run them one at a time with `--status-after` to get the next ref.
+
+**Usage:** Pass these IDs as arguments to commands:
+
+```bash
+but commit -b <branch-id> -m "message" <file-or-hunk-id>   # Commit selected changes to a branch
+but amend -t <commit-id> <file-or-hunk-id> <file-or-hunk-id>  # Amend file(s) or hunk(s) into commit
+but squash <commit-id> -t <commit-id> -m "message"         # Squash commits
+```
+
+IDs are positional and space-separated. `but help cli-ids` documents every ID kind in detail.
+
+## Parallel vs Stacked Branches
+
+### Parallel Branches (Independent Work)
+
+Create with `but branch new <name>`:
+
+```
+main ──┬── api-endpoint (independent)
+       └── ui-update    (independent)
+```
+
+Use when:
+
+- Tasks don't depend on each other
+- Can be merged independently
+- No shared code between them
+
+Example: Adding a new API endpoint and updating button styles are independent.
+
+### Stacked Branches (Dependent Work)
+
+**To stack an existing branch** on top of another: `but move <child-branch-name> --above <parent-branch-name>`.
+
+**To create a new stacked branch** from scratch: `but branch new <name> -a <anchor>` — only use this when the child branch doesn't exist yet.
+
+```
+main ── authentication ── user-profile ── settings-page
+        (base)            (stacked)       (stacked)
+```
+
+Use when:
+
+- Feature B needs code from Feature A
+- Building incrementally on previous work
+- Creating a series of related changes
+
+Example: User profile page needs authentication to be implemented first.
+
+**Stacking two existing branches:** If both branches already exist and you need to make one depend on the other, use top-level `move`:
+```bash
+but move feature/frontend --above feature/backend
+# Now frontend is stacked on top of backend — both in the same stack
+```
+
+To tear off a branch from a stack:
+
+```bash
+but move feature/frontend --unstack
+```
+
+**Dependency tracking:** GitButler automatically tracks which changes depend on which commits. A dependent change can only be committed to the stack that contains the commits it depends on.
+
+## The Editing Model
+
+History editing is expressed as *sources* and a *target*. Sources are positional CLI IDs; the target
+is a flag. `zz` is a special ID meaning "the uncommitted area".
+
+`but squash` carries most of the model — what it does depends on the kinds you combine:
+
+| Sources          | Target (`-t`) | Operation                         | Example                       |
+| ---------------- | ------------- | --------------------------------- | ----------------------------- |
+| Commit(s)        | Commit        | Squash commits together           | `but squash mm -t nn -m "…"`  |
+| Branch           | Commit        | Squash a branch into a commit     | `but squash bu -t nn -m "…"`  |
+| Commit(s)        | Branch        | Squash into the branch's newest   | `but squash mm -t bu -m "…"`  |
+| Branch           | *(none)*      | Squash the branch into one commit | `but squash bu -m "…"`        |
+| Uncommitted file | Commit        | Amend the change into a commit    | `but squash a1 -t nn`         |
+| `zz`             | Commit        | Amend everything into a commit    | `but squash zz -t nn`         |
+| Commit           | `zz`          | Uncommit the commit               | `but squash mm -t zz`         |
+| Committed file   | Commit        | Move the file to another commit   | `but squash nn:a -t mm`       |
+
+**Message flags:** the rows whose sources are commits or branches compose a NEW message, so without
+`-m` they open an editor and block — always pass one. The remaining rows reuse the target's message
+and need no flag, and `-t zz` rejects message flags outright.
+
+The two amend rows overlap with `but amend` — prefer `but amend -t nn a1`, which does only that and
+takes the same IDs. Reach for `squash` when the sources are commits, branches, or committed files,
+which `amend` does not accept.
+
+The other editing commands are narrower entry points on the same model:
+
+- `but amend -t <commit> <changes>` — amend uncommitted files/hunks into a known commit
+- `but uncommit <commits-or-committed-files>` — move committed work back to uncommitted; committed
+  files in one call must come from one commit
+- `but move <sources> --above|--below|--branch|--unstack` — relocate commits, committed files, or a
+  branch; this is the command with position control
+- `but discard <changes>` — drop work instead of relocating it
+
+## Dependency Tracking
+
+GitButler tracks dependencies between changes automatically.
+
+### How It Works
+
+```
+Commit C1: Added function foo()
+Commit C2: Added function bar()
+Uncommitted: Call to foo() in new code
+```
+
+The uncommitted change **depends on** C1 (because it calls `foo()`).
+
+**Implications:**
+
+1. Can't commit this change to a stack that doesn't contain C1
+2. When amending it into history, it belongs in C1 (or a commit after C1)
+3. If you try to move the change, GitButler prevents invalid operations
+
+### Why This Matters
+
+Prevents you from creating broken states:
+
+- Can't move dependent code away from its dependencies
+- Can't commit changes to the wrong stack
+- Ensures each branch remains independently functional
+
+## Empty Commits as Placeholders
+
+You can create empty commits:
+
+```bash
+but commit --empty --below nn -m "TODO: Add error handling"
+but commit --empty --above nn -m "TODO: Add error handling"
+```
+
+**Use cases:**
+
+1. **Mark future work:** Create empty commit as placeholder for changes you'll make
+2. **Organize history:** Add semantic markers in commit history
+
+Example workflow:
+
+```bash
+but commit --empty --below rr -m "TODO: Add error handling"
+# Later, amend the error handling changes into the placeholder
+but amend -t <empty-commit-id> <file-id>
+```
+
+## Operation History (Oplog)
+
+Every operation in GitButler is recorded in the oplog (operation log).
+
+### What Gets Recorded
+
+- Branch creation/deletion
+- Commits
+- Squash/amend/move/uncommit/discard operations
+- Push/pull operations
+
+### Using Oplog
+
+```bash
+but oplog                      # View history
+but undo                       # Undo last operation
+but redo                       # Redo last undone operation
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
+but oplog restore <snapshot-id>  # Restore to specific point
+```
+
+Think of it as "git reflog" but for all GitButler operations, not just branch movements.
+
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but oplog restore` to earlier snapshot.
+
+## Applied vs Unapplied Branches
+
+Branches can be in two states:
+
+### Applied Branches
+
+- Active in your workspace
+- Merged into `gitbutler/workspace`
+- Changes visible in working directory
+- Can make changes and commit
+
+### Unapplied Branches
+
+- Exist but not active
+- Not in working directory
+- Can't make changes (must apply first)
+- Useful for temporarily setting aside work
+
+### Controlling State
+
+```bash
+but apply <branch-name>    # Make branch active
+but unapply <id>           # Make branch inactive
+```
+
+**Use cases:**
+
+- Unapply branches causing conflicts
+- Focus on subset of work (unapply others)
+- Temporarily set aside work without deleting
+
+## Conflict Resolution Mode
+
+When `but pull` causes conflicts, affected commits are marked as conflicted.
+
+### Resolution Workflow
+
+1. **Identify:** the `but pull` summary lists each conflicted commit's ID, oldest first (`but status` also shows them)
+2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers. With several conflicted commits, resolve the oldest first: finishing a lower commit rebases the ones above it
+3. **Fix conflicts:** Edit files, remove conflict markers (`but resolve status` re-lists what remains when several files are conflicted)
+4. **Finalize:** `but resolve finish` or `but resolve cancel` — finish reports leftover markers and the surviving uncommitted changes, so no follow-up check is needed
+
+### During Resolution
+
+- You're in a special mode focused on that commit
+- Other GitButler operations are limited
+- `but status` shows you're in resolution mode
+- Must finish or cancel before continuing normal work
+
+## Read-Only Git Commands
+
+Git commands that don't modify state are safe to use:
+
+**Safe (read-only):**
+
+- `git log` - View history
+- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs)
+- `git show` - View commits
+- `git blame` - See line history
+- `git reflog` - View reference log
+
+**Don't use in a GitButler workspace:**
+
+- `git status` - Misleading: shows merged workspace state, not individual stacks; missing CLI IDs that agents need
+- `git commit` - Commits to the workspace merge commit, not your branch
+- `git checkout` - Breaks workspace model
+- `git rebase` - Conflicts with GitButler's management
+- `git merge` - Use `but land` instead
+
+**Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/.claude/skills/gitbutler/references/examples.md
+++ b/.claude/skills/gitbutler/references/examples.md
@@ -1,0 +1,475 @@
+# GitButler CLI Workflow Examples
+
+Real-world examples of common workflows.
+
+**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `nn`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status -fv`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs are short change-ID prefixes that stay stable across history edits (e.g., `kyn`; commits without a change ID fall back to a sha prefix), and file/hunk/stack IDs are auto-generated (e.g., `r`, `r:c`, `h0`). All IDs are unique across entity types.
+
+## Example 1: Starting Independent Parallel Work
+
+**Scenario:** Need to work on two independent features: a new API endpoint and UI styling updates.
+
+```bash
+# 1. Check current state
+but status -fv
+
+# 2. Create two independent (parallel) branches
+but branch new api-endpoint
+but branch new ui-styling
+
+# 3. Make changes to multiple files
+# (edit api/users.js and components/Button.svelte)
+
+# 4. Check what's uncommitted
+but status -fv
+
+# 5. Commit specific files by passing their CLI IDs (recommended for agents)
+# Use CLI ID values from but status -fv output (e.g., branch IDs and file IDs)
+# Multiple IDs are space-separated positional arguments.
+but commit -b <api-branch-id> -m "Add user details endpoint" <api-file-id>
+but commit -b <ui-branch-id> -m "Update button hover styles" <ui-file-id>
+
+# Follow-up fix that belongs in a commit you just made? Amend it in.
+# Add --status-after only when the next step needs resulting workspace IDs or details.
+# but amend -t <api-commit-id> <api-fix-file-id> <api-fix-hunk-id>
+
+# 6. Create pull requests (auto-pushes the branches; -m sets the PR title so no editor opens)
+but pr new <api-branch-id> -m "Add user details endpoint"
+but pr new <ui-branch-id> -m "Update button hover styles"
+```
+
+**Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
+
+## Example 2: Building Stacked Features
+
+**Scenario:** Need to add authentication, then build a user profile page that requires auth.
+
+```bash
+# 1. Check current state and update
+but pull
+but status -fv
+
+# 2. Create base branch for authentication
+but branch new add-authentication
+
+# 3. Implement auth and commit
+# (edit auth/login.js, auth/middleware.js)
+but status -fv
+but commit -b bu -m "Add JWT authentication" <file-ids>
+
+# 4. Create stacked branch anchored on authentication
+but branch new user-profile -a bu
+
+# 5. Implement profile page (depends on auth)
+# (edit pages/profile.js)
+but status -fv
+but commit -b bv -m "Add user profile page" <file-ids>
+
+# 6. Create stacked pull requests through GitButler (auto-pushes the stack)
+but pr new bv -t
+```
+
+**Result:** Two PRs where user-profile targets add-authentication, with GitButler stack information in the PR descriptions.
+
+## Example 3: Amending Fixes Into Existing Commits
+
+**Scenario:** Made a small typo fix that should be part of an existing commit, not a new commit.
+
+```bash
+# 1. Check current commits and uncommitted changes
+but status -fv
+
+# Output shows:
+# Branch: feature-x (bu)
+# Commits:
+#   nn: Implement feature logic
+#   mm: Add feature tests
+# Uncommitted:
+#   a1: fix-typo.js
+
+# 2. Decide which commit the fix belongs to
+# (the typo is in code introduced by nn, so it belongs in nn)
+
+# 3. Amend the file into that commit
+but amend -t nn a1    # Amend just this file + get updated status
+```
+
+**Why amend?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits. You know what you changed and why — pick the target commit yourself.
+
+## Example 4: Reorganizing Commit History
+
+### Scenario A: Squashing Commits
+
+**Situation:** Made 5 small WIP commits, want to combine into one logical commit.
+
+```bash
+# Before (newest first):
+# rr: More tweaks
+# pp: Fix another thing
+# nn: Fix tests
+# mm: Adjust logic
+# kk: Initial implementation
+
+# Squash all commits in the branch into one
+but squash bu -m "Implement feature"
+
+# Or squash specific commits into a target commit
+but squash rr pp nn mm -t kk -m "Implement feature"
+```
+
+### Scenario B: Moving Files Between Commits
+
+**Situation:** A file was committed in the wrong commit, need to move it.
+
+```bash
+# 1. See which files are in which commits
+but status -fv
+
+# Output shows:
+# nn: Add API layer
+#   nn:a1  api.js
+#   nn:a2  utils.js
+# mm: Add config
+#   mm:c1  config.js
+
+# 2. Move utils.js from nn to mm
+but squash nn:a2 -t mm -u    # Committed file nn:a2 (utils.js) → commit mm, keep mm's message
+```
+
+### Scenario C: Moving Commit to Different Branch
+
+**Situation:** Committed to wrong branch, need to move commit.
+
+```bash
+# 1. Check current state
+but status -fv
+
+# Output:
+# Branch: feature-a (bu)
+#   nn: This should be in feature-b!
+#   mm: Correct commit
+
+# 2. Create or identify target branch
+but branch new feature-b    # Creates branch bv
+
+# 3. Move the commit
+but move nn -b bv    # Move nn to top of branch bv
+```
+
+## Example 5: Stacking Existing Branches
+
+**Scenario:** Two independent branches exist, but one now depends on the other. Stack them.
+
+```bash
+# 1. Check current state — two independent branches in separate stacks
+but status -fv
+
+# Output:
+# Stack 1: feature/backend (bu) — 2 commits
+# Stack 2: feature/frontend (bv) — 1 commit
+
+# 2. Frontend now depends on backend API — stack frontend on backend
+#    IMPORTANT: Prefer full branch NAMES here; branch CLI IDs are also accepted
+but move feature/frontend --above feature/backend
+
+# Result: Both branches are now in the same stack:
+# Stack 1: feature/backend → feature/frontend (stacked)
+
+# 3. Continue working — commits go to the right branch
+but status -fv
+but commit -b bu -m "Add caching layer" <id>   # To backend
+but commit -b bv -m "Add dialog component" <id> # To frontend
+```
+
+**Key point:** branch stack moves use branch **names** (like `feature/frontend`) or branch CLI IDs. Commit reordering still uses commit IDs.
+
+## Example 6: Conflict Resolution
+
+**Scenario:** After `but pull`, conflicts appear in a commit.
+
+```bash
+# 1. Pull updates
+but pull
+
+# Output:
+# Summary
+# ────────
+#   feature-x - conflicted
+#       nn Add validation
+
+# 2. Enter resolution mode using the commit ID from the pull output
+but resolve nn
+
+# Output:
+# Checking out conflicted commit nn
+# Conflicted files remaining:
+#   ✗ api/users.js
+#      12│<<<<<<< New base: ...
+#      ...conflict regions with line numbers...
+
+# 3. Edit each conflicted file to resolve
+# IMPORTANT: You MUST edit the files — do NOT just run `but resolve finish`
+# NEVER use `git add`, `git checkout --theirs/--ours`, or any git write command — just edit the files directly with the Edit tool, then `but resolve finish`
+# (edit to remove every marker — <<<<<<< ||||||| ======= >>>>>>> — and keep correct content;
+#  with several conflicted files, `but resolve status` re-lists what remains)
+
+# 4. Finalize
+but resolve finish
+
+# Output:
+# ✓ Conflict resolution finalized successfully!
+# No conflict markers remain in the resolved files.
+# Workspace restored; uncommitted changes intact: ...
+# No follow-up status or marker scan needed — finish already reports both.
+```
+
+## Example 7: Complete Feature Development Workflow
+
+**Scenario:** Building a complete feature from start to finish.
+
+```bash
+# 1. Update to latest
+but pull
+
+# 2. Create branch for feature
+but branch new user-dashboard
+
+# 3. Make initial changes
+# (create dashboard.js, add routes)
+
+# 4. Check status and gather file IDs
+but status -fv
+
+# 5. First commit
+but commit -b bu -m "Add dashboard route and basic layout" <file-ids>
+
+# 6. Continue iterating
+# (add widgets, styling)
+but commit -b bu -m "Add dashboard widgets" <file-ids>
+but commit -b bu -m "Style dashboard components" <file-ids>
+
+# 7. Make small fix
+# (fix typo in widget)
+but amend -t <commit-id> a1    # Amend fix into the commit it belongs to
+
+# 8. Clean up if needed
+but squash bu -m "Add user dashboard"    # Combine all commits (optional)
+
+# 9. Create pull request (auto-pushes the branch)
+but pr new bu -m "Add user dashboard"
+
+# Output:
+# Created PR #123: https://github.com/org/repo/pull/123
+
+# 10. After PR is merged, update
+but pull
+```
+
+## Example 8: Working with Applied/Unapplied Branches
+
+**Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
+
+```bash
+# 1. Check active branches
+but status -fv
+
+# Output:
+# Applied branches:
+#   bu: feature-a
+#   bv: feature-b
+#   bw: feature-c
+
+# 2. Conflicts between feature-b and feature-c
+# Unapply them temporarily
+but unapply bv
+but unapply bw
+
+# 3. Focus on feature-a
+# (make changes, commit)
+but commit -b bu -m "Complete feature-a" <file-ids>
+
+# 4. Create PR for feature-a (auto-pushes)
+but pr new bu -m "Complete feature-a"
+
+# 5. Reapply other branches
+but apply feature-b
+but apply feature-c
+
+# 6. Deal with their conflicts now
+but resolve ...
+```
+
+## Example 9: Fixing History Before Pushing
+
+**Scenario:** Made several commits, realized you need to reword messages and reorder.
+
+```bash
+# 1. Current state
+but status -fv
+
+# Output (newest first):
+# Branch: feature-x (bu)
+#   rr: final commit
+#   pp: WIP
+#   nn: Fix stuff
+#   mm: Another fix
+#   kk: Initial
+
+# 2. Reword commit messages — commit refs are change-ID based and stay
+#    valid across rewords and other history edits
+but reword pp -m "Add validation logic"
+but reword nn -m "Fix edge case in parser"
+but reword mm -m "Update error messages"
+
+# 3. Move rr to be earlier
+but move rr --below nn    # Place rr directly below nn
+
+# 4. Squash similar commits
+but squash mm -t nn -u    # Combine error handling commits; -u keeps nn's message, drops mm's
+
+# Output (newest first):
+# Branch: feature-x (bu)
+#   pp: Add validation logic
+#   nn: Fix edge case in parser
+#   rr: final commit
+#   kk: Initial
+
+# 5. Push clean history
+but push feature-x
+```
+
+## Example 10: Daily Development Workflow
+
+**Typical day working with GitButler:**
+
+```bash
+# Morning: Start day
+but pull    # Get latest from team
+
+# Start new task
+but branch new fix-auth-bug  # Create branch for today's work
+
+# Work and commit iteratively
+# (make changes)
+but status -fv              # Check changes
+but commit -b bu -m "Identify auth bug source" <file-ids>
+# (make more changes)
+but commit -b bu -m "Fix token expiration handling" <file-ids>
+# (small fix to existing code)
+but amend -t <commit-id> a1  # Amend fix into the commit it belongs to
+
+# Mid-day: Start urgent fix on different branch
+but branch new hotfix-login  # Parallel branch for urgent work
+# (make fix)
+but commit -b bv -m "Fix login redirect loop" <file-ids>
+but pr new bv -m "Fix login redirect loop"    # Push and create PR immediately
+
+# Back to original work
+# (continue working on bu, auth bug fix)
+but commit -b bu -m "Add tests for token handling" <file-ids>
+
+# End of day: Clean up and create PR
+but squash bu -m "Fix auth bug"    # Combine into clean history
+but pr new bu -m "Fix auth bug"    # Push and create PR
+
+# After PR review: Make requested changes
+# (make changes based on feedback)
+but amend -t <commit-id> <file-id>  # Amend each fix into the commit it belongs to
+but push fix-auth-bug   # Push updated history
+```
+
+## Example 11: Recovering from Mistakes
+
+**Scenario:** Made changes you didn't mean to, need to undo.
+
+### Undo Last Operation
+
+```bash
+# Made a mistake
+but squash bu -m "..."    # Oops! Didn't mean to squash
+
+# Undo it
+but undo         # Reverts the squash
+```
+
+### Restore to Earlier Point
+
+```bash
+# View operation history
+but oplog
+
+# Output (snapshot refs are git SHAs, not CLI IDs):
+# 9c1f2ab 2026-01-02 [SQUASH] Squashed commits
+# f8a3733 2026-01-02 [COMMIT] Created commit
+# 4b70e19 2026-01-02 [AMEND] Amended commit
+# 1d5c806 2026-01-02 [BRANCH] Created branch
+
+# Restore to before the squash, using the SHA from the output
+but oplog restore f8a3733
+```
+
+### Discard Uncommitted Changes
+
+```bash
+# Changed a file but want to discard
+but status -fv
+
+# Output:
+# Uncommitted:
+#   a1: bad-changes.js
+
+# Discard it
+but discard a1
+```
+
+## Tips and Tricks
+
+### Quick Status Check
+
+```bash
+but status -fv    # File-centric view for quick overview
+```
+
+### Preview Before Doing
+
+```bash
+but push my-feature --dry-run   # See what would be pushed
+```
+
+### Multiple Commits From One Diff
+
+File/hunk IDs copied from the original output generally remain usable across
+commits. Chain `but commit` calls to split a dirty diff into several commits in
+one go:
+
+```bash
+but diff   # read the file/hunk IDs once
+
+but commit -b my-branch -m "Add parser" qs:5 qs:2 \
+  && but commit -b my-branch -m "Add tests" uo:d
+```
+
+The commits stack in the order you write them, so `Add parser` ends up below (older
+than) `Add tests`. Chain these commit commands when each references uncommitted IDs
+(plus the stable branch ID). If an ID stops resolving, re-read the diff and continue.
+Mutation output is concise by default. Add `--status-after` only when the next
+step needs workspace IDs or details that the mutation result does not provide.
+History edits — `amend`, `squash`, `move`, `uncommit`, `reword` — may also run in
+sequence off one status read when every commit ref involved is a change-ID ref;
+those stay stable across the edits. Run them one at a time when a ref is sha-based
+or `#N`-suffixed, or when the next command needs freshly issued IDs, and add
+`--status-after` to get them.
+
+
+### Auto-completion
+
+```bash
+eval "$(but completions zsh)"     # Add to ~/.zshrc
+eval "$(but completions bash)"    # Add to ~/.bashrc
+```
+
+### Viewing History
+
+```bash
+but show bu       # Show all commits in branch
+git log bu               # Traditional git log (read-only, still works)
+```

--- a/.claude/skills/gitbutler/references/reference.md
+++ b/.claude/skills/gitbutler/references/reference.md
@@ -1,0 +1,588 @@
+# GitButler CLI Command Reference
+
+Agent-focused reference for useful `but` commands.
+
+## Contents
+
+- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
+- [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
+- [Committing](#committing) - `commit`
+- [Editing History](#editing-history) - `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
+- [Conflict Resolution](#conflict-resolution) - `resolve`
+- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
+- [Workspace Maintenance](#workspace-maintenance) - `clean`
+- [History & Undo](#history--undo) - `undo`, `oplog`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
+- [Selected Options](#selected-options)
+
+## Inspection (Understanding State)
+
+### `but status`
+
+Overview of branch, stack, commit, and workspace state. Use this when you need existing branch/stack/commit/conflict context. For selected dirty-file or hunk commits, start with `but diff` instead.
+
+```bash
+but status              # Compact overview with branch, stack, commit IDs, and commit subjects
+but status -fv          # File-centric view with full commit details and file IDs
+but status --verbose    # Detailed information
+but status --upstream   # Show upstream relationship
+```
+
+Shows:
+
+- Applied/unapplied branches in workspace
+- Uncommitted and assigned changes
+- Commits on each stack
+- CLI IDs to use in other commands
+
+The first token on each line is that line's ID. Commit lines lead with the commit's change ID (stable across history edits); commits without a change ID lead with a sha prefix, which goes stale after history edits. Verbose output appends an informational `(sha …)` after the timestamp — do not pass the sha to commands.
+
+### `but show <id>`
+
+Details about a commit or branch.
+
+```bash
+but show <id>           # Show details
+but show <id> --verbose # Show with full messages and file details
+```
+
+### `but diff [target]`
+
+Display diff for file, branch, stack, or commit.
+
+```bash
+but diff                # Diff for entire workspace; best first command for selective dirty commits
+but diff <file-id>      # Diff for specific file
+but diff <branch-id>    # Diff for all changes in branch
+but diff <commit-id>    # Diff for specific commit
+```
+
+`but diff` accepts at most one target. Bare `but diff` shows every uncommitted file;
+inspect committed files or other entities one target at a time. Unlike `commit`,
+`amend`, and `discard`, it does not accept several positional IDs.
+
+**Hunk IDs:** For uncommitted changes, `but diff` shows each hunk with an ID (e.g., `qs:5`, `uo:d`). Pass these IDs to `but commit` for fine-grained, hunk-level commits.
+
+For the full CLI ID model, `but help cli-ids` documents every ID kind and its stability.
+
+## Branching
+
+### `but branch`
+
+List all branches (default when no subcommand).
+
+```bash
+but branch              # List branches
+but branch list [filter]  # Filter branches by name (case-insensitive substring)
+but branch list --no-ahead  # Skip commits-ahead calculation (faster)
+but branch list --no-check  # Skip clean-merge check (faster)
+but branch list -r      # Show only remote branches
+but branch list -l      # Show only local branches
+but branch list -a      # Show all branches (not just active + 20 most recent)
+but branch list --empty  # Include empty branches
+but branch list --review  # Fetch and display review information
+```
+
+### `but branch new [name]`
+
+Create a new branch.
+
+```bash
+but branch new                      # Generated branch name
+but branch new feature              # Independent branch (parallel work)
+but branch new feature -a <anchor>  # Stacked branch (dependent work)
+```
+
+Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
+
+For "commit these selected changes on a new branch", prefer `but commit -b <branch> -m "message" <ids>` instead of a separate `but branch new` or preflight `but status -fv` — `-b` creates the branch when it does not exist.
+
+### `but apply <branch-name>`
+
+Activate a branch in the workspace.
+
+```bash
+but apply feature-branch  # Activate branch in workspace
+```
+
+Default human output reports whether the branch was applied, was already active, or conflicted. Conflicts are reported as non-zero CLI errors.
+
+### `but unapply <id>`
+
+Deactivate a branch from the workspace.
+
+```bash
+but unapply <id>         # Deactivate branch from workspace
+```
+
+The identifier can be a CLI ID pointing to a stack or branch, or a branch name. If a branch is specified, the entire stack containing that branch will be unapplied.
+
+### `but branch delete <id>`
+
+Delete a branch.
+
+```bash
+but branch delete <id>
+but branch -d <id>      # Short form
+```
+
+### `but branch show <id>`
+
+Show commits ahead of base for a branch.
+
+```bash
+but branch show <id>
+but branch show <id> -f       # Show files modified in each commit with line counts
+but branch show <id> --ai     # Generate AI summary of branch changes
+but branch show <id> --check  # Check if branch merges cleanly into upstream
+but branch show <id> -r       # Fetch and display review information
+```
+
+### `but pick <source> [target]`
+
+Cherry-pick commits from unapplied branches into applied branches.
+
+```bash
+but pick <commit-sha> <branch>       # Pick specific commit into branch
+but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "nn")
+```
+
+Name both the source commit and the target branch. Passing a branch as the source opens an
+interactive commit picker, and omitting the target prompts for one when several branches exist —
+both block. The source can be a commit SHA (full or short) or a CLI ID from `but status`.
+
+## Committing
+
+### `but commit [CHANGES]...`
+
+Create a commit. Changes are positional CLI IDs; where the commit goes is a flag.
+
+```bash
+but commit -b <branch> -m "message"          # Commit ALL uncommitted changes to branch
+but commit -b <branch> -m "message" <id> <id>  # Commit specific files or hunks by CLI ID
+but commit -b <branch> -m "msg" -m "body"    # Repeat -m; parts joined by a blank line
+but commit --above <target> -m "message" <id>  # Place the commit above a commit or branch
+but commit --below <target> -m "message" <id>  # Place the commit below a commit or branch
+but commit -b <branch> --no-message <id>     # Commit without a message
+but commit --empty -b <branch> -m "message"  # Insert an empty commit
+```
+
+**Where the commit goes:** `-b`/`--branch`, `-A`/`--above`, and `-B`/`--below` are mutually exclusive.
+
+- `-b <branch>` places the commit at the tip of `<branch>`, creating it as an unstacked branch if it does not exist. `-b` with no value creates a branch with a generated name. Targeting a branch that exists but is not applied is an error.
+- `--above <commit>` / `--below <commit>` insert relative to a commit on that commit's branch. Against a branch, they create a new branch above/below it.
+- With no branches applied, a new branch is created. With one applied stack, the commit goes to its top branch's tip. With more than one stack, a targeting flag is **required** — otherwise the command fails with "Unclear where to commit. Found more than one stack". The gate is stacks, not branches: several branches stacked together take an untargeted commit on the stack's top branch.
+
+**Important:** `but commit -b <branch> -m "msg"` with no IDs commits ALL uncommitted changes. Pass IDs to commit only specific files or hunks.
+
+`but commit` is not supported from linked worktrees. Use Git directly for the worktree-local commit, and do not run `but setup` there.
+
+**Committing specific files or hunks:** Start with `but diff` for selective dirty commits, then pass CLI IDs as positional arguments:
+- **File IDs** from `but diff` or `but status -fv`: commits entire files
+- **Hunk IDs** (`<file-id>:<hunk-id>`) from `but diff`: commits individual hunks
+- IDs are space-separated (`<id> <id>`). Commas are not separators — `a1,b2` is parsed as a single ID and fails to resolve.
+
+**Placing commits:** Use `--above <target>` or `--below <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — add `--status-after` when subsequent history edits need fresh refs.
+
+**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. Mutation output is concise by default. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
+
+Example: `but commit -b my-branch -m "Fix bug" ab cd` commits files/hunks `ab` and `cd`.
+
+Example new branch: `but commit -b feature/contact-form -m "Validate contact form input" ab cd` creates `feature/contact-form` and commits only those selected file or hunk IDs.
+
+To commit specific hunks from a file with multiple changes, use `but diff` to see hunk IDs, then specify them individually.
+
+Edge case: if wanted and unwanted edits are in the same hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit those IDs, then restore the leftover lines so they remain uncommitted.
+
+## Editing History
+
+### `but squash <SOURCES>... [-t <target>]`
+
+Move changes into a target. Sources are positional; the target is `-t`/`--target`.
+This one command covers squashing, amending, and uncommitting.
+
+```bash
+but squash <commit> -t <commit> -m "msg"           # Squash one commit into another
+but squash <commit> <commit> -t <commit> -m "msg"  # Squash several commits into a target
+but squash <branch> -m "msg"                       # Squash all commits on a branch into one
+but squash <branch> -t <commit> -m "msg"           # Squash a branch into a commit, removing the branch
+but squash <commit> -t <branch> -m "msg"           # Target a branch: squashes into its newest commit
+but squash <file-or-hunk-id> -t <commit>           # Amend an uncommitted change (`but amend` does this)
+but squash zz -t <commit>                          # Amend all uncommitted changes into a commit
+but squash <commit> -t zz                          # Uncommit a commit
+but squash <commit-id>:<file-id> -t <commit>       # Move a committed file into another commit
+```
+
+All sources must be the same kind (all commits, all branches, all uncommitted changes, `zz`, or all
+committed files) and committed-file sources must come from one commit. If `-t` is omitted, `<SOURCES>`
+must be exactly one branch, which squashes that branch's commits together.
+
+Message flags (mutually exclusive). Commit and branch sources compose a new message, so without a
+flag they open an editor and block — always pass one. Uncommitted and committed-file sources reuse
+the target's message and need no flag:
+
+```bash
+-m "msg"                # New message; repeat -m to append paragraphs
+--no-message            # No message
+-u, --use-target-message  # Keep the target's message, drop the sources'
+--use-source-message      # Keep the sources' message, drop the target's
+```
+
+None of the message flags may be used when the target is `zz`.
+
+For multiple independent squash groups, prefer newer/top groups first; change-ID refs from
+one status read stay valid across squashes (the target keeps its ref), so the
+groups may run in sequence — use `--status-after` to get fresh refs only
+when a ref is sha-based or `#N`-suffixed.
+
+### `but amend -t <commit-or-branch> <SOURCES>...`
+
+Amend uncommitted files/hunks into a specific commit. Use when you know exactly which commit the change belongs to — prefer it over the equivalent `squash` form. Sources must be uncommitted; `amend` rejects commits and committed files, so use `squash` or `move` for those. A branch target resolves to that branch's newest commit, so name the commit explicitly when the change belongs further down.
+
+```bash
+but amend -t <commit-id> <file-id> <hunk-id>
+but amend -t <branch> <file-id>       # Amends into the branch's newest commit (its tip)
+```
+
+Decide the target commit yourself: check `but status -fv`, find the commit the change logically belongs to, then amend into it.
+
+### `but move <SOURCES>... <--above|--below|--branch|--unstack>`
+
+Move commits, committed files, or a branch to a different location. Sources are positional and
+space-separated; a target flag is required.
+
+```bash
+but move <commit> --below <target-commit>          # Place below target (older) — matches status order
+but move <commit> --above <target-commit>          # Place above target (newer)
+but move <commit> <commit> --below <target-commit> # Move an adjacent block in one command
+but move <commit> <commit> --above <target-commit> # Same block move, anchored from the other side
+but move <commit> -b <branch>                      # Move commit to the tip of a branch (created if missing)
+but move <commit> --unstack                        # Move commit onto a new unstacked branch
+but move <branch> --above <target-branch>          # Stack branch on top of target branch
+but move <branch> --unstack                        # Tear off (unstack) a branch
+but move <commit-id>:<file-id> --above <commit>    # Move a committed file into a new commit above another
+```
+
+Sources may not mix kinds, all committed files must come from the same commit, and only one branch
+may be moved at a time. Source order does not matter. For a branch source only `--above` and
+`--unstack` apply; `--below` and `-b <name>` require commit or committed-file sources. `--branch`
+with no value is equivalent to `--unstack`.
+
+### `but uncommit <SOURCES>...`
+
+Move commits or committed files back to the uncommitted area.
+
+```bash
+but uncommit <commit-id>                 # Uncommit an entire commit
+but uncommit <commit-id>:<file-id>       # Uncommit one file from its commit
+```
+
+Multiple whole commits may be passed together. Multiple committed-file sources must all come from
+the same commit; uncommit files from different commits in separate commands.
+
+When you need file and hunk IDs to recommit selectively, use
+`but uncommit <id> && but diff` in one shell call.
+
+### `but reword <id>`
+
+Reword commit message or rename branch.
+
+```bash
+but reword <id> -m "new"          # Always pass -m; without it an editor opens and blocks
+but reword <id> --fix-formatting  # Format to 72-char wrapping
+```
+
+### `but discard <CHANGES>...`
+
+Permanently drop branches, commits, or changes. Undo with `but undo`.
+
+```bash
+but discard <file-id>              # Discard an uncommitted file's changes
+but discard <hunk-id>              # Discard a single hunk
+but discard zz                     # Discard all uncommitted changes
+but discard <commit-id>            # Drop a commit
+but discard <commit-id>:<file-id>  # Drop one file's changes from its commit
+but discard <branch>               # Drop a branch and its commits
+```
+
+All provided IDs must be the same kind, and committed files must come from the same commit.
+
+## Conflict Resolution
+
+When commits have conflicts (history-editing commands warn about newly conflicted commits in their output; the `but pull` summary lists them; `but status` marks them as conflicted):
+
+### `but resolve <commit>`
+
+Enter resolution mode for a conflicted commit.
+
+```bash
+but resolve <commit-id>
+```
+
+### `but resolve status`
+
+Show remaining conflicted files.
+
+```bash
+but resolve status
+```
+
+### `but resolve finish`
+
+Finalize conflict resolution.
+
+```bash
+but resolve finish
+but resolve finish --status-after  # When clearing the last conflict and its workspace is needed
+```
+
+The concise result reports leftover markers, surviving uncommitted changes, every remaining
+conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the
+finish you expect to clear the last conflict only when the task needs the complete resulting
+workspace. When it says no conflicted commits remain, stop; do not run a verification status.
+
+### `but resolve cancel`
+
+Cancel conflict resolution and return to workspace mode.
+
+```bash
+but resolve cancel
+but resolve cancel --force
+```
+
+**Workflow:**
+
+1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
+2. Edit the conflicted files — remove every marker (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`; conflicts are diff3-style, so the `|||||||` common-ancestor section is present too) and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
+3. Finalize with `but resolve finish`; add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status
+4. If multiple commits are conflicted, repeat steps 1-3 for each one, oldest commit first — finishing a lower commit rebases the ones above it
+
+**Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
+
+## Remote Operations
+
+### `but push <branch>`
+
+Push a branch to remote. Always specify which branch to push: without one, `but push` prompts for a selection in interactive terminals and pushes ALL branches with unpushed commits otherwise. Accepts a full branch name or a branch CLI ID — prefer the name; it stays valid across mutations.
+
+```bash
+but push <branch-name>             # Push specific branch
+but push <branch-name> --dry-run   # Preview what would be pushed
+but push <branch-name> -s          # Skip force push protection checks
+but push <branch-name> --no-hooks  # Bypass pre-push hooks (--no-verify also works)
+```
+
+Force push is enabled by default with protection checks. Use `-s` only when intentionally skipping those checks.
+After a successful push, GitButler also synchronizes PR targets and stack descriptions for the
+selected branch and its ancestors. A forge update failure is reported as a warning; it does not
+turn the completed Git push into a failure.
+
+### `but pull`
+
+Update applied branches onto the latest target branch changes (usually `main`).
+Use this for "get latest from main" in a GitButler workspace.
+
+```bash
+but pull                      # Fetch and rebase applied branches
+but pull --check              # Dry-run preview: report what would happen, change nothing
+```
+
+Run `but pull` directly for a straightforward update; its output reports the result and `but undo`
+reverts it. Use `--check` first when the user or repository policy requires a preview without
+updating.
+Do not use raw `git pull` or `git rebase`.
+
+### `but pr`
+
+Create and manage pull requests.
+
+```bash
+but pr new <branch-id> -m "Title..."        # Push branch and create PR (recommended); first message line is title, rest is description
+but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
+but pr new <branch-id> -t     # Use default content (commit message), skip prompts
+but pr new <branch-id> --draft  # Create as draft
+but pr new <branch-id> --no-hooks  # Bypass pre-push hooks (--no-verify also works)
+but pr new <branch-id> -s     # Skip force-push protection checks
+but pr --draft                # Top-level draft flag
+but pr auto-merge <selector>  # Enable auto-merge
+but pr set-draft <selector>   # Mark review as draft
+but pr set-ready <selector>   # Mark review as ready
+```
+
+**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push and pre-push hooks run by default.
+Use `--no-hooks` to bypass pre-push hooks when needed.
+Review creation remains successful if the follow-up stack synchronization fails, and reports that
+partial success as a warning.
+
+Selectors for `auto-merge`, `set-draft`, and `set-ready` can be branch names, branch IDs, stack IDs, or numeric review IDs, comma-separated.
+
+Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
+
+**Stacked branches:** Use `but pr` for stacked PRs. It creates reviews against the right bases and updates GitButler stack footers in PR descriptions. Creating stacked PRs with `gh pr create` or another forge tool loses that stack-aware behavior. To publish a whole stack, run `but pr new <top-branch-id> -t`; custom messages (`-m` or `-F`) only apply to the selected branch, while dependent branches use default messages (commit title/description).
+
+When the selected branch sits on dependencies that already have PRs, the summary lists those as "PR already exists for ..." and ends with the newly created review. The already-exists lines are normal stack reporting, not a failure to create the selected branch's PR.
+
+Requires forge integration to be configured via `but config forge auth`.
+
+Same-repository pull requests are automatically registered with GitHub's native stacked pull
+requests API when the repository is enrolled in GitHub's private preview; otherwise GitButler uses
+description footers. `but config forge github-stacks disable` opts out. The setting is
+project-local and shared with Desktop.
+
+### `but land <branch>`
+
+Land a branch directly onto the target (e.g. `origin/master`), skipping a pull request. Fast-forwards
+when possible, otherwise makes a signed merge commit; for a `gb-local` target it moves the refs
+locally. Then reconciles the remaining branches like `but pull`.
+
+```bash
+but land <branch-id> --yes                  # Land onto the target (--yes required non-interactively)
+but land <branch-id> --no-ff --yes          # Force a merge commit instead of fast-forwarding
+but land <top-branch> --whole-stack --yes   # Land an entire stack by naming its top segment
+```
+
+Direct target updates are hard to reverse, so confirmation is required (agents must pass `--yes`).
+A branch stacked on other segments is refused (its tip would also publish them); `--whole-stack`
+is the explicit opt-in, and only the stack's top segment can be named with it.
+
+## Workspace Maintenance
+
+### `but clean`
+
+Remove empty branches from the workspace.
+
+```bash
+but clean                   # Delete all empty branches
+but clean --dry-run         # Preview which branches would be deleted
+but clean --pull            # Pull latest changes first, then clean
+but clean --include-upstream # Also remove branches with upstream-only commits
+```
+
+A branch is considered empty if it has no local commits and no assigned changes. Branches with upstream-only commits are preserved by default unless `--include-upstream` is used.
+
+The entire operation is a single oplog entry — use `but undo` to restore all deleted branches.
+
+## History & Undo
+
+### `but undo` / `but redo`
+
+Undo or redo operations.
+
+```bash
+but undo
+but redo
+```
+
+### `but oplog`
+
+View operation history.
+
+```bash
+but oplog
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
+```
+
+Shows all operations with snapshot IDs.
+
+### `but oplog restore <snapshot>`
+
+Restore to a specific oplog snapshot.
+
+```bash
+but oplog restore <snapshot-id>
+```
+
+## Setup & Configuration
+
+### `but setup`
+
+Initialize GitButler in current git repository.
+
+```bash
+but setup
+but setup --init              # Also initialize a new git repo if none exists
+```
+
+Converts a regular Git repository to the managed GitButler workspace model. Use `--init` in
+non-interactive environments (CI/CD) to ensure a Git repository exists before setup. When the
+experimental single-branch feature is enabled, normal CLI use does not require this command: the
+repository is registered and its target is inferred lazily without checking out
+`gitbutler/workspace` or installing setup hooks.
+
+Rerunning `but setup` on an already-configured project also repairs a missing default target — for
+example if `virtual_branches.toml` was reset while the target survived in Git config — so it is the
+recovery path when target configuration looks broken.
+
+### `but teardown`
+
+Exit GitButler mode and return to normal git workflow.
+
+```bash
+but teardown
+```
+
+### `but config`
+
+View and manage GitButler configuration.
+
+```bash
+but config
+but config user               # Also: forge, target, metrics, feature, ui, ai
+but config ai openai          # Also: anthropic, ollama, lmstudio, openrouter
+but config target             # Show the current target branch
+but config target origin/main # Set the fetch target
+but config push-remote         # Show the current push remote
+but config push-remote origin  # Set the push remote without changing the target
+but config feature                         # List configurable feature flags
+but config feature single-branch           # Show a feature flag's value
+but config feature single-branch enable    # Also: disable
+```
+
+### `but update check`
+
+Manage GitButler CLI and app updates.
+
+```bash
+but update check
+but update install
+but update install [nightly|release|0.18.7]
+```
+
+### `but skill`
+
+Manage installed GitButler skill files.
+
+```bash
+but skill check
+but skill check --update
+but skill install --detect
+```
+
+## Selected Options
+
+Useful to agents:
+
+- `-C, --current-dir <PATH>` - Run as if started in different directory
+- `-h, --help` - Show help for command. Avoid routine help probes; use this reference first.
+
+## External commands (PATH helpers)
+
+> Important: Not available for Windows yet
+
+Similar to Git, if `<command>` is not a built-in `but` command and `but-<command>` exists on `PATH`, `but` runs that executable instead (for example `but forecast …` invokes `but-forecast …`).
+
+Restriction: `<command>` must consist of characters in the set `[a-zA-Z_-]`
+
+## Getting More Help
+
+```bash
+but --help                    # List all commands
+but <subcommand> --help       # Detailed help for specific command
+```
+
+Prefer this reference over exploratory help calls. Use command-specific help when required syntax
+is missing or a command fails; use top-level help only to discover an undocumented command.
+
+Full documentation: <https://docs.gitbutler.com/cli-overview>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This is a monorepo containing shareable configuration packages for various devel
 ## Project Structure
 
 - **Monorepo Manager**: Turborepo with Bun workspaces
-- **Package Manager**: bun@1.3.11
+- **Package Manager**: bun
 - **Node Version**: ^24.0.0
 - **License**: MIT
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,30 +12,30 @@
         "@mheob/commitlint-config": "workspace:*",
         "@mheob/oxfmt-config": "workspace:*",
         "@mheob/oxlint-config": "workspace:*",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "cspell": "^10.0.1",
         "czg": "^1.13.1",
         "lefthook": "^2.1.10",
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "turbo": "^2.10.5",
+        "oxfmt": "^0.62.0",
+        "oxlint": "^1.77.0",
+        "turbo": "^2.10.8",
         "typescript": "^7.0.2",
       },
     },
     "packages/commitlint-config": {
       "name": "@mheob/commitlint-config",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@mheob/internal": "workspace:*",
         "@mheob/oxfmt-config": "workspace:*",
         "@mheob/oxlint-config": "workspace:*",
         "@mheob/tsconfig": "workspace:*",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "czg": "^1.13.1",
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "tsdown": "^0.22.9",
+        "oxfmt": "^0.62.0",
+        "oxlint": "^1.77.0",
+        "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
@@ -45,45 +45,45 @@
     },
     "packages/internal": {
       "name": "@mheob/internal",
-      "version": "0.0.0-dev",
+      "version": "0.0.0",
       "dependencies": {
-        "tsdown": "^0.22.9",
+        "tsdown": "^0.22.14",
       },
       "devDependencies": {
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "tsdown": "^0.22.9",
+        "oxfmt": "^0.62.0",
+        "oxlint": "^1.77.0",
+        "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
       },
     },
     "packages/oxfmt-config": {
       "name": "@mheob/oxfmt-config",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "devDependencies": {
         "@mheob/internal": "workspace:*",
         "@mheob/oxlint-config": "workspace:*",
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "tsdown": "^0.22.9",
+        "oxfmt": "^0.62.0",
+        "oxlint": "^1.77.0",
+        "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
-        "oxfmt": ">=0.59.0",
+        "oxfmt": ">=0.62.0 <1.0.0",
       },
     },
     "packages/oxlint-config": {
       "name": "@mheob/oxlint-config",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "devDependencies": {
         "@mheob/internal": "workspace:*",
-        "eslint-plugin-better-tailwindcss": "^4.6.1",
+        "eslint-plugin-better-tailwindcss": "^4.7.0",
         "eslint-plugin-jsonc": "^3.3.0",
         "eslint-plugin-regexp": "^3.1.1",
-        "eslint-plugin-storybook": "^10.5.2",
-        "eslint-plugin-yml": "^3.6.0",
-        "oxfmt": "^0.59.0",
-        "oxlint": "^1.74.0",
-        "tsdown": "^0.22.9",
+        "eslint-plugin-storybook": "^10.5.6",
+        "eslint-plugin-yml": "^3.7.0",
+        "oxfmt": "^0.62.0",
+        "oxlint": "^1.77.0",
+        "tsdown": "^0.22.14",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
@@ -92,7 +92,7 @@
         "eslint-plugin-regexp": "^3.1.0",
         "eslint-plugin-storybook": "^10.3.4",
         "eslint-plugin-yml": "^3.3.1",
-        "oxlint": "^1.74.0",
+        "oxlint": "^1.77.0",
       },
       "optionalPeers": [
         "eslint-plugin-better-tailwindcss",
@@ -104,7 +104,7 @@
     },
     "packages/tsconfig": {
       "name": "@mheob/tsconfig",
-      "version": "2.2.1",
+      "version": "3.0.1",
     },
   },
   "trustedDependencies": [
@@ -534,81 +534,81 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.74.0", "", { "os": "android", "cpu": "arm" }, "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.77.0", "", { "os": "android", "cpu": "arm" }, "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.74.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.77.0", "", { "os": "android", "cpu": "arm64" }, "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.74.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.77.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.74.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.77.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.74.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.77.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.77.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.77.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.74.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.77.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.77.0", "", { "os": "linux", "cpu": "none" }, "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.74.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.77.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.77.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.74.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.77.0", "", { "os": "none", "cpu": "arm64" }, "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.74.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.77.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.74.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
 
@@ -660,17 +660,17 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rqROo9zsF/P9RqsdtbLD1nFJicjSrYyvQ9kNJC38AbxA3pAs6VAlATvtvOFx7bqOv6vicf20SP9kF33avJjy2w=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.5", "", { "os": "linux", "cpu": "x64" }, "sha512-RoSSiNFUxi27zLJuM9F6GyWWjHgLch9t6nwD6K0FkXRirZkTLlzIj6IhFnK8H9++nefLtdFqylE4vGjZAv6AAA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-4ZComcpzmHGmVynQqvvi+iZOSq/tBvY1SltXB8g4NZRsrA01W8E+yRL8RNM+PLoyWsrCnJa8xa+DkWkv+xg4iQ=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.5", "", { "os": "win32", "cpu": "x64" }, "sha512-eL2Iyj4DbMINq1Sr1w0iAi6nAiZOF16KSlRGwCJpVh+IWZeY33MAsLHVOBMj1xoFtncVJXclCVpTPL2nBoYkFg=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.8", "", { "os": "win32", "cpu": "x64" }, "sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-sog+wP+8YSJrdWZ/rUJg8xghVTrwoG+BrSlDQpnK5fzSgJHn1INRWXbVWRH0d3vX8dBI01E3yxXRre9Dn+OXQA=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -686,7 +686,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.60.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.60.1", "@typescript-eslint/types": "^8.60.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw=="],
 
@@ -754,51 +754,55 @@
 
     "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
 
-    "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.6.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uR1OCnftxC89GP6ZLPbaAXU9wdycmXt5BUQAOaDUmU/b38WJefse4RcL793rsOw1rkb8UC3UqP9F8hQ0lDB5xg=="],
+    "@yuku-codegen/binding-android-arm64": ["@yuku-codegen/binding-android-arm64@0.8.3", "", { "os": "android", "cpu": "arm64" }, "sha512-/EKnnqwvN7xYoVDhQEIEJTdPDwGW1wkFz/2Eku3ES/IJd4lcQh/OaIDFBmoJKvpe12enrb1TIoYh1fxasGXolA=="],
 
-    "@yuku-codegen/binding-darwin-x64": ["@yuku-codegen/binding-darwin-x64@0.6.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-b5m/NymPwAV8OYmWPK0GwVeXw/D7EMIr1GkgL9fW/JCFDvkSkBTz8cbGl5Jkoxr+bamOZy4C1ySngpU///4CFQ=="],
+    "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.8.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DFAOliF5YIPv3ayNHGOJhIun6Af4kMaL/YXxf8ZtD1qrOIMFnX/AQBhwfvLalhwmmxuGA8AUteaKRHBvdKZFVA=="],
 
-    "@yuku-codegen/binding-freebsd-x64": ["@yuku-codegen/binding-freebsd-x64@0.6.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-wLTe/QeBF37qb4bR++t/jLP3LQ7oS76lsZigk7J10IR2GwD4w8GJqhIm1NsAwho6OjWDNnfxkkw/Oadf/jex4Q=="],
+    "@yuku-codegen/binding-darwin-x64": ["@yuku-codegen/binding-darwin-x64@0.8.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-WlMh4/oEibaTzE9j5Zq8qnsrH4Ii4kWdcDv/Pj2Rb/MYSrKghtg+bxbWpPe/6zJD21p9zZBApQUxl8ECpZOJuQ=="],
 
-    "@yuku-codegen/binding-linux-arm-gnu": ["@yuku-codegen/binding-linux-arm-gnu@0.6.5", "", { "os": "linux", "cpu": "arm" }, "sha512-Clah7LByDMBFkHKeRsUrqoftiyocoYaAmDc7aM14S9qghvKPnbTAtvrG8QOLMkWviWS+rQ94YWFGqzk1cRxAnA=="],
+    "@yuku-codegen/binding-freebsd-x64": ["@yuku-codegen/binding-freebsd-x64@0.8.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hoDOpPP0FTxPSD+6w0Gs4p8iL1yXe6jjIXcdzNxyT1KE6B3JI6O0gTIWQISJ+8QyNpNjIwBb7nHCdRavktJM6A=="],
 
-    "@yuku-codegen/binding-linux-arm-musl": ["@yuku-codegen/binding-linux-arm-musl@0.6.5", "", { "os": "linux", "cpu": "arm" }, "sha512-3ghZT7Dtp5tzIyfSFWcLFxtwnXjrrqLhO+MTuw3Am03K9Coo2NQICwwA9DN2HBrb8KXES1U43an1rNgzRw9xog=="],
+    "@yuku-codegen/binding-linux-arm-gnu": ["@yuku-codegen/binding-linux-arm-gnu@0.8.3", "", { "os": "linux", "cpu": "arm" }, "sha512-nNW0GGMJyF04pK4A7Kq7WAYtUWU9uI5ugDAoXl9yHpd3IIZ8UI+zFlM01e+ZGWnQcdxYYLumeRe/EjzZT9bVfQ=="],
 
-    "@yuku-codegen/binding-linux-arm64-gnu": ["@yuku-codegen/binding-linux-arm64-gnu@0.6.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-9zT+uVEtVJkvm0Ba5BkUgBXNqw3kcolV9RAf0kSgIe44bi5Lp6MPqCRm9JrWnJTZOySzPII3oRNRl9dtBlOdLg=="],
+    "@yuku-codegen/binding-linux-arm-musl": ["@yuku-codegen/binding-linux-arm-musl@0.8.3", "", { "os": "linux", "cpu": "arm" }, "sha512-/jpxKhO8AV5TmXgT3R2Gv3YctKRUhyDzd5bQw8TiJ3O4z7qerHzoW2kE40fPAO3L434/IZtZbdhr8HuOqiwECA=="],
 
-    "@yuku-codegen/binding-linux-arm64-musl": ["@yuku-codegen/binding-linux-arm64-musl@0.6.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Uyi/vT++0gyVsyan3XvEii8AWbc+yFJ3M0GEloup7eBx1j4FtK7oq23F6mbQD1gNaozGKkN74fCJpIxF176hZA=="],
+    "@yuku-codegen/binding-linux-arm64-gnu": ["@yuku-codegen/binding-linux-arm64-gnu@0.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-CYhLJfnCknabfLvUjsanxC5s3BBtZHUwfzdDL7GcqShIRQh2qqgG7pPfFrFJ6Jp56kkjKXkfluFGn9nnIv0nZg=="],
 
-    "@yuku-codegen/binding-linux-x64-gnu": ["@yuku-codegen/binding-linux-x64-gnu@0.6.5", "", { "os": "linux", "cpu": "x64" }, "sha512-JZzAbPDh5eQ2GRAAbo7cKcFabPQ9UEAQglk1BE0psoWUDt1wktp4ZX9ZJgDgF9EbSH3UUACo0lIkWUtSjRyRoQ=="],
+    "@yuku-codegen/binding-linux-arm64-musl": ["@yuku-codegen/binding-linux-arm64-musl@0.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-c6gEdnI0MgA7/rVw6CACMciSbAcxVwLyD/jSBbMLWUeqqbysCNGrGPAHdpSaadpz3W1bd+OdXt9XWjfm66708w=="],
 
-    "@yuku-codegen/binding-linux-x64-musl": ["@yuku-codegen/binding-linux-x64-musl@0.6.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Dmh6Qhoo1UNM10eDLs/DND8E3cLfQQboFfZgnnNNIJ2RQ/G0GXGh7Kzff1QmglUNuRami42NkTrsF9VrkCttZg=="],
+    "@yuku-codegen/binding-linux-x64-gnu": ["@yuku-codegen/binding-linux-x64-gnu@0.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-CRVZ9Rw5lIah/PpWeShWv7XiUCMY15N6rZRA2sEZrQvc5Az7Dv9/wsDMa6oBMkfQLXuDkFo4G1QOYyWbebjejg=="],
 
-    "@yuku-codegen/binding-win32-arm64": ["@yuku-codegen/binding-win32-arm64@0.6.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-UAq2wLFT0mRN2rzJfZjmaqVMJD9kYywARc6Wk8Ggnm4p8yJYigNxMkJ0gt3bpd0MOnvre4LFEDyAMr4esRubuQ=="],
+    "@yuku-codegen/binding-linux-x64-musl": ["@yuku-codegen/binding-linux-x64-musl@0.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-G12Nhecjmv7OlbCX6Y4HU4wYYePd111kTE+yTjbitnt+P3m8bNegtYG4ZGo4scGTq8cKsLF4xcda1XNzCUA6nQ=="],
 
-    "@yuku-codegen/binding-win32-x64": ["@yuku-codegen/binding-win32-x64@0.6.5", "", { "os": "win32", "cpu": "x64" }, "sha512-hlEo+UIMHaEoLHe8woLr9eI6fz+8LRwdRrid/iegVU1N+53zkh4WMkI8N7e4vUNKKMVN2kJo6Z73J+JfskHO1g=="],
+    "@yuku-codegen/binding-win32-arm64": ["@yuku-codegen/binding-win32-arm64@0.8.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-i8bpXWaMlik9DvFl+89emEx3RZFtSd21Vlt0UrnPvUC7h8NGElP2SwQcdcG+pPmihFIYJAoIuJLw7YdQcFcDkA=="],
 
-    "@yuku-parser/binding-darwin-arm64": ["@yuku-parser/binding-darwin-arm64@0.6.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QVdaZzj9T3KdaprM8VYpiYIFJrcJB347P2U3bg683nPQaDNmX733CFtCqpkc1KHccFf199EXx4OazkJlnHvImA=="],
+    "@yuku-codegen/binding-win32-x64": ["@yuku-codegen/binding-win32-x64@0.8.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vlYymeTSsx+qxZoNvdl6KehgYDaQC4Sk/9KUnM3V2mriyCwSdhW7lqdpQGl+RLGsDTxyuRGjzGIjgRWk3lohmA=="],
 
-    "@yuku-parser/binding-darwin-x64": ["@yuku-parser/binding-darwin-x64@0.6.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-9omiEXwzJo3hsJiaohFek44wKRmnNy8o8acf8PXJdVo19I9O5eY7c3Nhca1DRTozoLqIJEI68CH8OoR2/Dv7ww=="],
+    "@yuku-parser/binding-android-arm64": ["@yuku-parser/binding-android-arm64@0.8.3", "", { "os": "android", "cpu": "arm64" }, "sha512-vySYRsMeul9ssvxeHdxgS9ZUIcq7gqljWNqgokjJE0uQWvVvOprihJ6hOsiifVqWsla0BMc3vAFBvNS9QqCw7g=="],
 
-    "@yuku-parser/binding-freebsd-x64": ["@yuku-parser/binding-freebsd-x64@0.6.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-0BZ14CHc8H3EHmlAMhxTDVMYijsT1nNZUhl6JTm/xzl+Gaun/vahgdaJaFESuweLeZ1WnwVfPVPvjsdfnbTN8g=="],
+    "@yuku-parser/binding-darwin-arm64": ["@yuku-parser/binding-darwin-arm64@0.8.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+wpB/wqhiZ685Y77I+lj6v9pHSAJ3Y+QMHJmvch0Q0ahIMbNwtKk3s54MhtjCMKO1qpjPbyN/PjuHDg2hbKaVQ=="],
 
-    "@yuku-parser/binding-linux-arm-gnu": ["@yuku-parser/binding-linux-arm-gnu@0.6.5", "", { "os": "linux", "cpu": "arm" }, "sha512-VidTdzelGosQDkVkU4X/9qrILPT5HunzL5shW9jrq860naAEjGS/41a4s3J5KBRsKRHscwOsbtSzUev1TMdgfg=="],
+    "@yuku-parser/binding-darwin-x64": ["@yuku-parser/binding-darwin-x64@0.8.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-jKqiWejj4zVy7pPtEGu4/Ty+pG1h7ooQOXIkm7shKZTSwTU9X8X+eoH11uIeKHZi2SQWV0GhNz0J56eerseysQ=="],
 
-    "@yuku-parser/binding-linux-arm-musl": ["@yuku-parser/binding-linux-arm-musl@0.6.5", "", { "os": "linux", "cpu": "arm" }, "sha512-Xes/SwXQiPFPqLMhnwjRv0s6mlm6V7+jpw/kmCMkal9Q0UfS4hVpFo2T5NNIKNLCj5qAZ+2EPtgDBz0S1lH4xg=="],
+    "@yuku-parser/binding-freebsd-x64": ["@yuku-parser/binding-freebsd-x64@0.8.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-FC7zSwzFzd4z9bsId07CiHLR+Iw6yW/LzIQhL5AUtPUuVXLgEyx0rilgbRUYkl1CT3GJcLpkh63WuPZUSgCDzw=="],
 
-    "@yuku-parser/binding-linux-arm64-gnu": ["@yuku-parser/binding-linux-arm64-gnu@0.6.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-MaFn3Vh+kBETYXtPYBaCQUMsUk5SqSatM+mp9Vz7COuCKXim7cG8kGcUpqq93wegLEkkEnv8pyiDFFx/gmNOiQ=="],
+    "@yuku-parser/binding-linux-arm-gnu": ["@yuku-parser/binding-linux-arm-gnu@0.8.3", "", { "os": "linux", "cpu": "arm" }, "sha512-So61j88b9/ygDnUPlWCm1EUPw4HSxAyDjrNHKgud5N3aRDQ3kw94nW7TriXbo7GBXID9oBHCMNm1r1Fof/Df5Q=="],
 
-    "@yuku-parser/binding-linux-arm64-musl": ["@yuku-parser/binding-linux-arm64-musl@0.6.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-s7GAjJ7kzmnEBVAq5c5B+h/DCOSZG7WqTNpFRYUVGQU+D8wf1gMnfDQ5v8zFdByhpHiW+HNerxI8sml5dl47Rw=="],
+    "@yuku-parser/binding-linux-arm-musl": ["@yuku-parser/binding-linux-arm-musl@0.8.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Nmnn20yJvSSKL8ZdtqReBRSGCDkSMqR5jEk/Sk/cdIdZmqVD49Z6M7w2GbMjdrxMI1MBPbsWFMMWxa93cd5t5g=="],
 
-    "@yuku-parser/binding-linux-x64-gnu": ["@yuku-parser/binding-linux-x64-gnu@0.6.5", "", { "os": "linux", "cpu": "x64" }, "sha512-5/+mLrZdCtGoKOw/zNJC0+fSy4aKI97JvPm5rr8DXui/l3+BrvU5g7czp1DVHN67I7VzTLizu2n2y5cz2CjzEg=="],
+    "@yuku-parser/binding-linux-arm64-gnu": ["@yuku-parser/binding-linux-arm64-gnu@0.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Lfgw7AXJ0rxu6BMPGgfc8HLJWEIr8BHhCzcQp/75k+NM90uCLkHlBNqIg/K42KlSvBgAvu9euOvjdswib+4qJA=="],
 
-    "@yuku-parser/binding-linux-x64-musl": ["@yuku-parser/binding-linux-x64-musl@0.6.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Svj4h/WZQ1VdAxaFJrakVi85IzUJPYWcNw15gNPoeNg+/SGGTTkTeUzODiMRY/8ioJ/k3+/K7zQwASIEBF7L3Q=="],
+    "@yuku-parser/binding-linux-arm64-musl": ["@yuku-parser/binding-linux-arm64-musl@0.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-cfRyu87xsJ0tFkHNsnMC4Rq6+xsFJ6i2dc4VAH52d2qLvykEJU/Mdi3ul1O2PyOApX/LoLT3uQZ0fWs3D5XE4w=="],
 
-    "@yuku-parser/binding-win32-arm64": ["@yuku-parser/binding-win32-arm64@0.6.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-N96G8zoKihVwhMaH+kLp8MFIA1i3+dRaBO4KYK0otTPVdX+3uS2wpUY5vDLj4JbkKARuQA/DUmfgjleoXL6ugA=="],
+    "@yuku-parser/binding-linux-x64-gnu": ["@yuku-parser/binding-linux-x64-gnu@0.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-GcQQCUuYxbm6P1n+io/A50rvWKDeWHutIp6rW0ycDOZuEQjOb8hDVgS88+NDyOnd9FfS0/Z6GXopcRFDyKpzOg=="],
 
-    "@yuku-parser/binding-win32-x64": ["@yuku-parser/binding-win32-x64@0.6.5", "", { "os": "win32", "cpu": "x64" }, "sha512-RP7rz120SodZI/vUc1H4uzIMEZrxeG//d11qWUI5inMbU4YSnufJAScwjV+qQHxD3FAwoueNxsPjrVxagwAymg=="],
+    "@yuku-parser/binding-linux-x64-musl": ["@yuku-parser/binding-linux-x64-musl@0.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-rMkImBGZzg7GZlj8krYtdiezyjYI4igjKWMut5T65jHyNWFigMQrEpn9mDIBflloW9FKhGE3mN6yTZ/N+4HRwg=="],
 
-    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.5.43", "", {}, "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ=="],
+    "@yuku-parser/binding-win32-arm64": ["@yuku-parser/binding-win32-arm64@0.8.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/2Pl2cAzCXWxah8FqJapEj/ikpt9cEutEZFCa0hnbfrshkn5+C+aBM3ZDq62d1jsgQjBMmqr5HVhJUA4OAG/Tg=="],
+
+    "@yuku-parser/binding-win32-x64": ["@yuku-parser/binding-win32-x64@0.8.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ntnvjoan9jnfLhn7Kn3h8j/bhsbVdQSVmKUqFULKtmwImLCJVHOJbLL4qbEJyrOQ7r/FBL1/c/dRvx/AQWzzXg=="],
+
+    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.8.3", "", {}, "sha512-9LN3HYs3A9qSPVFunsxlbfwBcUgexti3TmhOzIxB/UH8zFuaHQJXTRDcN17DW6cp1GsyZtiZA7f18uIra36Jag=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -952,15 +956,15 @@
 
     "eslint-json-compat-utils": ["eslint-json-compat-utils@0.2.3", "", { "dependencies": { "esquery": "^1.6.0" }, "peerDependencies": { "eslint": "*", "jsonc-eslint-parser": "^2.4.0 || ^3.0.0" } }, "sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ=="],
 
-    "eslint-plugin-better-tailwindcss": ["eslint-plugin-better-tailwindcss@4.6.1", "", { "dependencies": { "@eslint/css-tree": "^4.0.4", "@valibot/to-json-schema": "^1.7.1", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "synckit": "^0.11.13", "tailwind-csstree": "^0.3.3", "tsconfig-paths-webpack-plugin": "^4.2.0", "valibot": "^1.4.2" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0", "oxlint": "^1.35.0", "tailwindcss": "^3.3.0 || ^4.1.17" }, "optionalPeers": ["eslint", "oxlint"] }, "sha512-Lr8mPyuaZ+dS6ATuJaPwcOFOpOUsRBs5TXyOPqiTzLy0SvK4+0G6usbklCuQn4QabwFtNKdSXwl2WxOIPvu0lQ=="],
+    "eslint-plugin-better-tailwindcss": ["eslint-plugin-better-tailwindcss@4.7.0", "", { "dependencies": { "@eslint/css-tree": "^4.0.4", "@valibot/to-json-schema": "^1.7.1", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "synckit": "^0.11.13", "tailwind-csstree": "^0.3.3", "tsconfig-paths-webpack-plugin": "^4.2.0", "valibot": "^1.4.2" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0", "oxlint": "^1.35.0", "tailwindcss": "^3.3.0 || ^4.1.17" }, "optionalPeers": ["eslint", "oxlint"] }, "sha512-lrdlVW4pzLPj/zX5HRqMhKPesGijDfRhnSRJMlNcsrCyJHsndmHCLKTiRNa1eREUZ6G3D3QjdLc+G4tlfGrmkw=="],
 
     "eslint-plugin-jsonc": ["eslint-plugin-jsonc@3.3.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.5.1", "@eslint/core": "^1.0.1", "@eslint/plugin-kit": "^0.7.0", "@ota-meshi/ast-token-store": "^0.3.0", "diff-sequences": "^29.6.3", "eslint-json-compat-utils": "^0.2.3", "jsonc-eslint-parser": "^3.1.0", "natural-compare": "^1.4.0", "synckit": "^0.11.12" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-CsTR8aDcShDg6A71ZppLaWiPoSo2J1Ivjm5/c4Mnb9sxgwWq+WG2PgeoAnj7SwzDPJB75tlHvLrGy6ntooIitg=="],
 
     "eslint-plugin-regexp": ["eslint-plugin-regexp@3.1.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.11.0", "comment-parser": "^1.4.0", "jsdoc-type-pratt-parser": "^7.0.0", "refa": "^0.12.1", "regexp-ast-analysis": "^0.7.1", "scslre": "^0.3.0" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA=="],
 
-    "eslint-plugin-storybook": ["eslint-plugin-storybook@10.5.2", "", { "dependencies": { "@typescript-eslint/types": "^8.48.0", "@typescript-eslint/utils": "^8.48.0" }, "peerDependencies": { "eslint": ">=8", "storybook": "^10.5.2" } }, "sha512-BPTbb8OKNAlQ2XubEQ6H1TeHG9nMygLrHC8cSVTfdIat65qbS568WYgNg//zlJWtZ9ZamyVkCp/na+LBbFPseA=="],
+    "eslint-plugin-storybook": ["eslint-plugin-storybook@10.5.6", "", { "dependencies": { "@typescript-eslint/types": "^8.60.0", "@typescript-eslint/utils": "^8.60.0" }, "peerDependencies": { "eslint": ">=8", "storybook": "^10.5.6" } }, "sha512-uOXhNkIH+iTdyViSmWnCrwtapasL57M3nq5yfST1H7y9djRLyuAIfNcf9cPBedc2G1oqI8jn3up/VHdN3y3Btw=="],
 
-    "eslint-plugin-yml": ["eslint-plugin-yml@3.6.0", "", { "dependencies": { "@eslint/core": "^1.0.1", "@eslint/plugin-kit": "^0.7.0", "@ota-meshi/ast-token-store": "^0.3.0", "diff-sequences": "^29.0.0", "escape-string-regexp": "5.0.0", "natural-compare": "^1.4.0", "yaml-eslint-parser": "^2.0.0" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-8lSqBIiOJO8ms1gktdlNaVGm3zXQJiYeKhQmtIG66XzU58kFDOjQae4sufQEMGHC4bP8VxiaH3tjU5PpDB6euw=="],
+    "eslint-plugin-yml": ["eslint-plugin-yml@3.7.0", "", { "dependencies": { "@eslint/core": "^1.0.1", "@eslint/plugin-kit": "^0.7.0", "@ota-meshi/ast-token-store": "^0.3.0", "diff-sequences": "^29.0.0", "escape-string-regexp": "5.0.0", "natural-compare": "^1.4.0", "yaml-eslint-parser": "^2.0.0" }, "peerDependencies": { "eslint": ">=9.38.0" } }, "sha512-cLkVHdBHyRifThJA3ufuEW+imPRO7rHBQXdWgthouY6qEapUw8/0zW6V8NcMEGWzuMykc/ITYl6AuhZLPzI+fw=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -1148,7 +1152,7 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
@@ -1160,9 +1164,9 @@
 
     "oxc-resolver": ["oxc-resolver@11.20.0", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.20.0", "@oxc-resolver/binding-android-arm64": "11.20.0", "@oxc-resolver/binding-darwin-arm64": "11.20.0", "@oxc-resolver/binding-darwin-x64": "11.20.0", "@oxc-resolver/binding-freebsd-x64": "11.20.0", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0", "@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0", "@oxc-resolver/binding-linux-arm64-gnu": "11.20.0", "@oxc-resolver/binding-linux-arm64-musl": "11.20.0", "@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0", "@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0", "@oxc-resolver/binding-linux-riscv64-musl": "11.20.0", "@oxc-resolver/binding-linux-s390x-gnu": "11.20.0", "@oxc-resolver/binding-linux-x64-gnu": "11.20.0", "@oxc-resolver/binding-linux-x64-musl": "11.20.0", "@oxc-resolver/binding-openharmony-arm64": "11.20.0", "@oxc-resolver/binding-wasm32-wasi": "11.20.0", "@oxc-resolver/binding-win32-arm64-msvc": "11.20.0", "@oxc-resolver/binding-win32-x64-msvc": "11.20.0" } }, "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g=="],
 
-    "oxfmt": ["oxfmt@0.59.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.59.0", "@oxfmt/binding-android-arm64": "0.59.0", "@oxfmt/binding-darwin-arm64": "0.59.0", "@oxfmt/binding-darwin-x64": "0.59.0", "@oxfmt/binding-freebsd-x64": "0.59.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0", "@oxfmt/binding-linux-arm-musleabihf": "0.59.0", "@oxfmt/binding-linux-arm64-gnu": "0.59.0", "@oxfmt/binding-linux-arm64-musl": "0.59.0", "@oxfmt/binding-linux-ppc64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-gnu": "0.59.0", "@oxfmt/binding-linux-riscv64-musl": "0.59.0", "@oxfmt/binding-linux-s390x-gnu": "0.59.0", "@oxfmt/binding-linux-x64-gnu": "0.59.0", "@oxfmt/binding-linux-x64-musl": "0.59.0", "@oxfmt/binding-openharmony-arm64": "0.59.0", "@oxfmt/binding-win32-arm64-msvc": "0.59.0", "@oxfmt/binding-win32-ia32-msvc": "0.59.0", "@oxfmt/binding-win32-x64-msvc": "0.59.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w=="],
+    "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
-    "oxlint": ["oxlint@1.74.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.74.0", "@oxlint/binding-android-arm64": "1.74.0", "@oxlint/binding-darwin-arm64": "1.74.0", "@oxlint/binding-darwin-x64": "1.74.0", "@oxlint/binding-freebsd-x64": "1.74.0", "@oxlint/binding-linux-arm-gnueabihf": "1.74.0", "@oxlint/binding-linux-arm-musleabihf": "1.74.0", "@oxlint/binding-linux-arm64-gnu": "1.74.0", "@oxlint/binding-linux-arm64-musl": "1.74.0", "@oxlint/binding-linux-ppc64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-musl": "1.74.0", "@oxlint/binding-linux-s390x-gnu": "1.74.0", "@oxlint/binding-linux-x64-gnu": "1.74.0", "@oxlint/binding-linux-x64-musl": "1.74.0", "@oxlint/binding-openharmony-arm64": "1.74.0", "@oxlint/binding-win32-arm64-msvc": "1.74.0", "@oxlint/binding-win32-ia32-msvc": "1.74.0", "@oxlint/binding-win32-x64-msvc": "1.74.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA=="],
+    "oxlint": ["oxlint@1.77.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.77.0", "@oxlint/binding-android-arm64": "1.77.0", "@oxlint/binding-darwin-arm64": "1.77.0", "@oxlint/binding-darwin-x64": "1.77.0", "@oxlint/binding-freebsd-x64": "1.77.0", "@oxlint/binding-linux-arm-gnueabihf": "1.77.0", "@oxlint/binding-linux-arm-musleabihf": "1.77.0", "@oxlint/binding-linux-arm64-gnu": "1.77.0", "@oxlint/binding-linux-arm64-musl": "1.77.0", "@oxlint/binding-linux-ppc64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-gnu": "1.77.0", "@oxlint/binding-linux-riscv64-musl": "1.77.0", "@oxlint/binding-linux-s390x-gnu": "1.77.0", "@oxlint/binding-linux-x64-gnu": "1.77.0", "@oxlint/binding-linux-x64-musl": "1.77.0", "@oxlint/binding-openharmony-arm64": "1.77.0", "@oxlint/binding-win32-arm64-msvc": "1.77.0", "@oxlint/binding-win32-ia32-msvc": "1.77.0", "@oxlint/binding-win32-x64-msvc": "1.77.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -1232,7 +1236,7 @@
 
     "rolldown": ["rolldown@1.2.0", "", { "dependencies": { "@oxc-project/types": "=0.140.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.0", "@rolldown/binding-darwin-arm64": "1.2.0", "@rolldown/binding-darwin-x64": "1.2.0", "@rolldown/binding-freebsd-x64": "1.2.0", "@rolldown/binding-linux-arm-gnueabihf": "1.2.0", "@rolldown/binding-linux-arm64-gnu": "1.2.0", "@rolldown/binding-linux-arm64-musl": "1.2.0", "@rolldown/binding-linux-ppc64-gnu": "1.2.0", "@rolldown/binding-linux-s390x-gnu": "1.2.0", "@rolldown/binding-linux-x64-gnu": "1.2.0", "@rolldown/binding-linux-x64-musl": "1.2.0", "@rolldown/binding-openharmony-arm64": "1.2.0", "@rolldown/binding-wasm32-wasi": "1.2.0", "@rolldown/binding-win32-arm64-msvc": "1.2.0", "@rolldown/binding-win32-x64-msvc": "1.2.0" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA=="],
 
-    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.11", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3", "yuku-ast": "^0.1.7", "yuku-codegen": "^0.6.3", "yuku-parser": "^0.6.3" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-DnBl4USSTV/h/sgy//QjCLHVo2JypE/52P5QugGeYaEqZmjBz/FYESOld0MhyIhul2U3Vsh41K63UWGHhJU/qQ=="],
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.14", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.4", "yuku-ast": "^0.8.0", "yuku-codegen": "^0.8.0", "yuku-parser": "^0.8.0" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
@@ -1310,11 +1314,11 @@
 
     "tsconfig-paths-webpack-plugin": ["tsconfig-paths-webpack-plugin@4.2.0", "", { "dependencies": { "chalk": "^4.1.0", "enhanced-resolve": "^5.7.0", "tapable": "^2.2.1", "tsconfig-paths": "^4.1.2" } }, "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA=="],
 
-    "tsdown": ["tsdown@0.22.9", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.5", "rolldown": "~1.2.0", "rolldown-plugin-dts": "^0.27.9", "semver": "^7.8.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.9", "@tsdown/exe": "0.22.9", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-/0QEjQEhOU1t1YxOIAGzFN7bIssd8P0pBpkOmNLCQi3c5UtrcMF5bvq3f30xHJNW9QCA9aUNcNAorMr2CTd6Lg=="],
+    "tsdown": ["tsdown@0.22.14", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.4", "picomatch": "^4.0.5", "rolldown": "~1.2.0", "rolldown-plugin-dts": "^0.27.13", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "verkit": "^0.3.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.14", "@tsdown/exe": "0.22.14", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "turbo": ["turbo@2.10.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.5", "@turbo/darwin-arm64": "2.10.5", "@turbo/linux-64": "2.10.5", "@turbo/linux-arm64": "2.10.5", "@turbo/windows-64": "2.10.5", "@turbo/windows-arm64": "2.10.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ=="],
+    "turbo": ["turbo@2.10.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.8", "@turbo/darwin-arm64": "2.10.8", "@turbo/linux-64": "2.10.8", "@turbo/linux-arm64": "2.10.8", "@turbo/windows-64": "2.10.8", "@turbo/windows-arm64": "2.10.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1331,6 +1335,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
+
+    "verkit": ["verkit@0.3.1", "", {}, "sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg=="],
 
     "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
 
@@ -1364,11 +1370,11 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "yuku-ast": ["yuku-ast@0.1.7", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" } }, "sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA=="],
+    "yuku-ast": ["yuku-ast@0.8.3", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.3" } }, "sha512-8x34yU5uhHUnJXzy2Qvjvec/vE9BzS0/2khVT1MsLmSLO/P8Q1Wp8IxHv+IhD+HMYETk6kherOSvP4JPWw2joQ=="],
 
-    "yuku-codegen": ["yuku-codegen@0.6.5", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-codegen/binding-darwin-arm64": "0.6.5", "@yuku-codegen/binding-darwin-x64": "0.6.5", "@yuku-codegen/binding-freebsd-x64": "0.6.5", "@yuku-codegen/binding-linux-arm-gnu": "0.6.5", "@yuku-codegen/binding-linux-arm-musl": "0.6.5", "@yuku-codegen/binding-linux-arm64-gnu": "0.6.5", "@yuku-codegen/binding-linux-arm64-musl": "0.6.5", "@yuku-codegen/binding-linux-x64-gnu": "0.6.5", "@yuku-codegen/binding-linux-x64-musl": "0.6.5", "@yuku-codegen/binding-win32-arm64": "0.6.5", "@yuku-codegen/binding-win32-x64": "0.6.5" } }, "sha512-g8gbp05j2NNSKe0Uu2ViBRvawzXaWggxS9YwcVJ2d3I99VxbeOeENSUseA8AXPCZj/gcLkQxl7uhTmtK36qh8Q=="],
+    "yuku-codegen": ["yuku-codegen@0.8.3", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.3" }, "optionalDependencies": { "@yuku-codegen/binding-android-arm64": "0.8.3", "@yuku-codegen/binding-darwin-arm64": "0.8.3", "@yuku-codegen/binding-darwin-x64": "0.8.3", "@yuku-codegen/binding-freebsd-x64": "0.8.3", "@yuku-codegen/binding-linux-arm-gnu": "0.8.3", "@yuku-codegen/binding-linux-arm-musl": "0.8.3", "@yuku-codegen/binding-linux-arm64-gnu": "0.8.3", "@yuku-codegen/binding-linux-arm64-musl": "0.8.3", "@yuku-codegen/binding-linux-x64-gnu": "0.8.3", "@yuku-codegen/binding-linux-x64-musl": "0.8.3", "@yuku-codegen/binding-win32-arm64": "0.8.3", "@yuku-codegen/binding-win32-x64": "0.8.3" } }, "sha512-okdo5bb+TfebQa4JOjz9QxeT34D6CcBxu8dxaPUdFEKRdLkp+D2Fah2OanepK+XTyPXdmAJzAo9iXvYvZ/5rmg=="],
 
-    "yuku-parser": ["yuku-parser@0.6.5", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.6.5", "@yuku-parser/binding-darwin-x64": "0.6.5", "@yuku-parser/binding-freebsd-x64": "0.6.5", "@yuku-parser/binding-linux-arm-gnu": "0.6.5", "@yuku-parser/binding-linux-arm-musl": "0.6.5", "@yuku-parser/binding-linux-arm64-gnu": "0.6.5", "@yuku-parser/binding-linux-arm64-musl": "0.6.5", "@yuku-parser/binding-linux-x64-gnu": "0.6.5", "@yuku-parser/binding-linux-x64-musl": "0.6.5", "@yuku-parser/binding-win32-arm64": "0.6.5", "@yuku-parser/binding-win32-x64": "0.6.5" } }, "sha512-9A5zaOqE3X3wcPOTK97CYInpKwaUGYnwfHWasJaI2Je1OhI4pQmRA6YCSh7oKewEb2iJM4xlJdbwwj4Aydty7w=="],
+    "yuku-parser": ["yuku-parser@0.8.3", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.3", "yuku-ast": "^0.8.3" }, "optionalDependencies": { "@yuku-parser/binding-android-arm64": "0.8.3", "@yuku-parser/binding-darwin-arm64": "0.8.3", "@yuku-parser/binding-darwin-x64": "0.8.3", "@yuku-parser/binding-freebsd-x64": "0.8.3", "@yuku-parser/binding-linux-arm-gnu": "0.8.3", "@yuku-parser/binding-linux-arm-musl": "0.8.3", "@yuku-parser/binding-linux-arm64-gnu": "0.8.3", "@yuku-parser/binding-linux-arm64-musl": "0.8.3", "@yuku-parser/binding-linux-x64-gnu": "0.8.3", "@yuku-parser/binding-linux-x64-musl": "0.8.3", "@yuku-parser/binding-win32-arm64": "0.8.3", "@yuku-parser/binding-win32-x64": "0.8.3" } }, "sha512-KPQcpF9aj77ywlJBIkQWCQ9DObdxnCA8AJdUOmA5CZZx042Xt4+dvbQmPJfWxF3E+KG5dVAZ2fBKuDJ8VsKWgA=="],
 
     "@changesets/apply-release-plan/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,7 +9,7 @@ function getScopes() {
 	const defaultScopes = ['deps', 'release', 'repo'];
 	const packagesPath = path.resolve(currentPath, 'packages');
 	const packages = existsSync(packagesPath)
-		? readdirSync(packagesPath).map(packageName => packageName.replace('-config', ''))
+		? readdirSync(packagesPath).map((packageName) => packageName.replace('-config', ''))
 		: [];
 	return [...defaultScopes, ...packages];
 }

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
 		"@mheob/commitlint-config": "workspace:*",
 		"@mheob/oxfmt-config": "workspace:*",
 		"@mheob/oxlint-config": "workspace:*",
-		"@types/node": "^26.1.1",
+		"@types/node": "^26.1.2",
 		"cspell": "^10.0.1",
 		"czg": "^1.13.1",
 		"lefthook": "^2.1.10",
-		"oxfmt": "^0.59.0",
-		"oxlint": "^1.74.0",
-		"turbo": "^2.10.5",
+		"oxfmt": "^0.62.0",
+		"oxlint": "^1.77.0",
+		"turbo": "^2.10.8",
 		"typescript": "^7.0.2"
 	},
 	"overrides": {

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -2,8 +2,7 @@
 
 To make my configurations a bit easier I share my [Commitlint](https://commitlint.js.org/) config.
 
-Another notable tool for using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) is
-[cz-git](https://cz-git.qbb.sh/).
+Another notable tool for using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) is [cz-git](https://cz-git.qbb.sh/).
 
 ## Install
 

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -37,11 +37,11 @@
 		"@mheob/oxfmt-config": "workspace:*",
 		"@mheob/oxlint-config": "workspace:*",
 		"@mheob/tsconfig": "workspace:*",
-		"@types/node": "^26.1.1",
+		"@types/node": "^26.1.2",
 		"czg": "^1.13.1",
-		"oxfmt": "^0.59.0",
-		"oxlint": "^1.74.0",
-		"tsdown": "^0.22.9",
+		"oxfmt": "^0.62.0",
+		"oxlint": "^1.77.0",
+		"tsdown": "^0.22.14",
 		"typescript": "^7.0.2"
 	},
 	"peerDependencies": {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -18,12 +18,12 @@
 		"lint:fix": "bun run --bun oxlint --fix"
 	},
 	"dependencies": {
-		"tsdown": "^0.22.9"
+		"tsdown": "^0.22.14"
 	},
 	"devDependencies": {
-		"oxfmt": "^0.59.0",
-		"oxlint": "^1.74.0",
-		"tsdown": "^0.22.9",
+		"oxfmt": "^0.62.0",
+		"oxlint": "^1.77.0",
+		"tsdown": "^0.22.14",
 		"typescript": "^7.0.2"
 	}
 }

--- a/packages/oxfmt-config/README.md
+++ b/packages/oxfmt-config/README.md
@@ -61,8 +61,7 @@ Also ships with file-specific overrides:
 
 ### VS Code
 
-Install the [OXC VS Code extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) and add to
-`.vscode/settings.json`:
+Install the [OXC VS Code extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) and add to `.vscode/settings.json`:
 
 ```jsonc
 {

--- a/packages/oxfmt-config/package.json
+++ b/packages/oxfmt-config/package.json
@@ -36,13 +36,13 @@
 	"devDependencies": {
 		"@mheob/internal": "workspace:*",
 		"@mheob/oxlint-config": "workspace:*",
-		"oxfmt": "^0.59.0",
-		"oxlint": "^1.74.0",
-		"tsdown": "^0.22.9",
+		"oxfmt": "^0.62.0",
+		"oxlint": "^1.77.0",
+		"tsdown": "^0.22.14",
 		"typescript": "^7.0.2"
 	},
 	"peerDependencies": {
-		"oxfmt": ">=0.59.0"
+		"oxfmt": ">=0.62.0 <1.0.0"
 	},
 	"peerDependenciesMeta": {
 		"oxfmt": {

--- a/packages/oxfmt-config/src/index.ts
+++ b/packages/oxfmt-config/src/index.ts
@@ -11,7 +11,7 @@ export const baseConfig = defineConfig({
 		{
 			files: ['*.md'],
 			options: {
-				printWidth: 130,
+				proseWrap: 'never',
 			},
 		},
 		{

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -26,7 +26,13 @@ Combine multiple configs by spreading them into the `extends` array:
 
 ```ts
 // oxlint.config.ts
-import { baseConfig, baseJsConfig, reactConfig, storybookConfig, tailwindcssConfig } from '@mheob/oxlint-config';
+import {
+	baseConfig,
+	baseJsConfig,
+	reactConfig,
+	storybookConfig,
+	tailwindcssConfig,
+} from '@mheob/oxlint-config';
 import { defineConfig } from 'oxlint';
 
 export default defineConfig({
@@ -65,8 +71,7 @@ The foundation for all projects. Enables the following OXLint plugins and covers
 | `node`       | Node.js safety rules             |
 | `oxc`        | OXC-native rules                 |
 
-Also ships with file-specific overrides for CLI files, config files, scripts, Markdown code blocks, and Vitest test files
-(enabling the `vitest` plugin for spec/test/bench files).
+Also ships with file-specific overrides for CLI files, config files, scripts, Markdown code blocks, and Vitest test files (enabling the `vitest` plugin for spec/test/bench files).
 
 ### `baseJsConfig`
 
@@ -162,8 +167,7 @@ bun add -D eslint-plugin-better-tailwindcss
 
 ### VS Code
 
-Install the [OXC VS Code extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) and add to
-`.vscode/settings.json`:
+Install the [OXC VS Code extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) and add to `.vscode/settings.json`:
 
 ```jsonc
 {

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -35,14 +35,14 @@
 	},
 	"devDependencies": {
 		"@mheob/internal": "workspace:*",
-		"eslint-plugin-better-tailwindcss": "^4.6.1",
+		"eslint-plugin-better-tailwindcss": "^4.7.0",
 		"eslint-plugin-jsonc": "^3.3.0",
 		"eslint-plugin-regexp": "^3.1.1",
-		"eslint-plugin-storybook": "^10.5.2",
-		"eslint-plugin-yml": "^3.6.0",
-		"oxfmt": "^0.59.0",
-		"oxlint": "^1.74.0",
-		"tsdown": "^0.22.9",
+		"eslint-plugin-storybook": "^10.5.6",
+		"eslint-plugin-yml": "^3.7.0",
+		"oxfmt": "^0.62.0",
+		"oxlint": "^1.77.0",
+		"tsdown": "^0.22.14",
 		"typescript": "^7.0.2"
 	},
 	"peerDependencies": {
@@ -51,7 +51,7 @@
 		"eslint-plugin-regexp": "^3.1.0",
 		"eslint-plugin-storybook": "^10.3.4",
 		"eslint-plugin-yml": "^3.3.1",
-		"oxlint": "^1.74.0"
+		"oxlint": "^1.77.0"
 	},
 	"peerDependenciesMeta": {
 		"eslint-plugin-better-tailwindcss": {


### PR DESCRIPTION
## Summary

Three focused commits:

1. **`chore(repo): add gitbutler CLI skill`** — adds the GitButler CLI skill (`SKILL.md` plus `concepts`, `examples`, `reference`) under `.claude/skills/gitbutler/`, so version control goes through `but` instead of raw `git` write commands. Repo tooling only, no changeset.
2. **`fix(deps): update workspace dependencies`** — bumps `oxfmt` (^0.62.0), `oxlint` (^1.77.0), `tsdown` (^0.22.14), `@types/node` (^26.1.2), `turbo` (^2.10.8), `eslint-plugin-better-tailwindcss` (^4.7.0), `eslint-plugin-storybook` (^10.5.6), and `eslint-plugin-yml` (^3.7.0). Raises the `oxlint` peer range in `oxlint-config` to `^1.77.0` and widens the `oxfmt` peer range in `oxfmt-config` to `>=0.62.0 <1.0.0`. `commitlint.config.js` picks up the new oxfmt arrow-parens default.
3. **`feat(oxfmt): format markdown with proseWrap never`** — the `*.md` override now uses `proseWrap: 'never'` instead of `printWidth: 130`, keeping each paragraph on one line so documentation diffs stay minimal.

## Changesets

- `.changeset/update-workspace-dependencies.md` — patch for `commitlint-config`, `oxfmt-config`, `internal`; minor for `oxlint-config` (peer range bump)
- `.changeset/markdown-prose-wrap-never.md` — minor for `oxfmt-config`

## Verification

- `bun run build` — 3/3 tasks successful
- `bun run lint` — 0 warnings, 0 errors across all 5 packages

## Breaking / behavioral notes

`proseWrap: 'never'` changes Markdown output for every consumer of `@mheob/oxfmt-config`. First format run after upgrading will unwrap existing hard-wrapped prose, producing a large one-time diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated Markdown formatting to prevent automatic prose wrapping, preserving author-defined line breaks.

- **Documentation**
  - Added comprehensive GitButler CLI guidance, including workflows for branching, commits, history editing, conflict resolution, recovery, and pull requests.
  - Added reference material covering concepts, commands, options, and practical examples.

- **Chores**
  - Updated development tooling configuration and standardized minor formatting conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->